### PR TITLE
docs: add Sequenzy email marketing skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Skills for the [OpenClaw](https://openclaw.ai) multi-agent system. 5,700+ skills
 - [openclawskills.net](https://openclawskills.net) - Web directory for OpenClaw skills.
 
 ---
+- [Sequenzy Email Marketing](https://clawhub.ai/polnikale/sequenzy-email-marketing) - OpenClaw-compatible skill for Sequenzy lifecycle email marketing and transactional email workflows.
 
 ## LangChain Tools
 


### PR DESCRIPTION
    ## Summary
    - Adds the Sequenzy email marketing Agent Skill to the relevant skill/resource section.
    - Keeps the description neutral and aligned with nearby entries.

    ## Links
    - Skill source: https://github.com/Sequenzy/skills/tree/main/skills/sequenzy-email-marketing
- ClawHub: https://clawhub.ai/polnikale/sequenzy-email-marketing

    ## Verification
    - Reviewed the target README section and contribution format.
    - Verified the Sequenzy skill source is public.
    - Changed files: README.md

    Diff stat:
    ```
    README.md | 1 +
 1 file changed, 1 insertion(+)
    ```
