### PR TITLE
Add NotFair — open-source SEO, GEO & paid-ads skills for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The [Agent Skills spec](https://github.com/anthropics/skills) is the emerging cr
 ### Domain-Specific
 
 - [K-Dense-AI/claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills) - Ready-to-use skills for research, science, engineering, analysis, finance and writing. ![GitHub stars](https://img.shields.io/github/stars/K-Dense-AI/claude-scientific-skills)
+- [nowork-studio/NotFair](https://github.com/nowork-studio/NotFair) - Open-source Claude Code skills for SEO, GEO, Google Ads, and Meta Ads; connects to live data via Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP. ![GitHub stars](https://img.shields.io/github/stars/nowork-studio/NotFair)
 
 ### Collections
 


### PR DESCRIPTION
Thanks for maintaining this directory — it's a genuinely useful cross-platform reference.

This PR adds [NotFair](https://github.com/nowork-studio/NotFair) to the **Domain-Specific** section under Agent Skills. NotFair is an open-source (MIT) set of Claude Code skills covering SEO/GEO, Google Ads, and Meta Ads. It pulls live data through Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP — so users can run audits, keyword research, bid adjustments, and creative analysis directly from their Claude Code session. It has around ~2.9k stars and is actively maintained.

It sits alongside the existing domain-specific entry (claude-scientific-skills) and follows the same format you use throughout the list.

Happy to reword the description, move it to a different section, or trim anything that doesn't fit the list's style — just let me know.