### PR TITLE
Add ax workflow recall skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The [Agent Skills spec](https://github.com/anthropics/skills) is the emerging cr
 - [travisvn/awesome-claude-skills](https://github.com/travisvn/awesome-claude-skills) - Claude Code workflow-focused skills. ![GitHub stars](https://img.shields.io/github/stars/travisvn/awesome-claude-skills)
 - [heilcheng/awesome-agent-skills](https://github.com/heilcheng/awesome-agent-skills) - Skills + tools + tutorials for Claude, Codex, Antigravity, Copilot. ![GitHub stars](https://img.shields.io/github/stars/heilcheng/awesome-agent-skills)
 - [skillmatic-ai/awesome-agent-skills](https://github.com/skillmatic-ai/awesome-agent-skills) - Architecture-focused skill resource. ![GitHub stars](https://img.shields.io/github/stars/skillmatic-ai/awesome-agent-skills)
+- [Necmttn/ax](https://github.com/Necmttn/ax/tree/main/skills) - Workflow recall skills for AI coding-agent sessions. ![GitHub stars](https://img.shields.io/github/stars/Necmttn/ax)
 - [rohitg00/awesome-claude-code-toolkit](https://github.com/rohitg00/awesome-claude-code-toolkit) - 135 agents, 35 skills, 42 commands, 120 plugins, 19 hooks. ![GitHub stars](https://img.shields.io/github/stars/rohitg00/awesome-claude-code-toolkit)
 
 ### Claude Code Ecosystem


### PR DESCRIPTION
## Summary
Add ax to the Agent Skills collections section.

## Why
The ax repo includes installable skills under `skills/`, including workflow recall for local AI coding-agent sessions.

## Checks
- git diff --check
- verified https://github.com/Necmttn/ax/tree/main/skills
- verified https://img.shields.io/github/stars/Necmttn/ax

Note: full markdown-link-check on README was stopped after hanging on the repo-wide link set; the added links were checked directly.

---

_Generated with [ax](https://github.com/Necmttn/ax)._

