### PR TITLE
Add agent-skill-groups to CLIs & Package Managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ Web-based platforms for discovering and installing agent skills and tools.
 
 Command-line tools for installing and managing agent skills.
 
+- [agent-skill-groups](https://github.com/go165/agent-skill-groups) - Scenario-profile CLI for grouping local Agent Skills across Codex, Claude Code, and OpenCode. ![GitHub stars](https://img.shields.io/github/stars/go165/agent-skill-groups)
 - [agent-skills-cli](https://github.com/Karanjot786/agent-skills-cli) - Universal CLI. Access 40,000+ skills from SkillsMP. Syncs to Cursor, Claude Code, Copilot, Codex, Antigravity.
 - [Smithery CLI](https://github.com/smithery-ai/cli) - Install, manage, and develop MCP servers and skills.
 - `npx antigravity-awesome-skills` - One-command install for 900+ skills from [sickn33/antigravity-awesome-skills](https://github.com/sickn33/antigravity-awesome-skills).


### PR DESCRIPTION
## Summary\n- Add go165/agent-skill-groups to the CLIs & Package Managers section.\n\n## Why this fits\n- It is a cross-platform CLI for managing local Agent Skills via scenario profiles.\n- It supports Codex, Claude Code, and OpenCode.\n\n## Validation\n- README-only change.\n- git diff --check passed locally.