### PR TITLE
Add Agentlas OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ Web-based platforms for discovering and installing agent skills and tools.
 Command-line tools for installing and managing agent skills.
 
 - [agent-skills-cli](https://github.com/Karanjot786/agent-skills-cli) - Universal CLI. Access 40,000+ skills from SkillsMP. Syncs to Cursor, Claude Code, Copilot, Codex, Antigravity.
+- [Agentlas OS](https://github.com/agentlas-ai/Agentlas-OS) - Builds and installs portable agent and team packages across supported hosts. ![GitHub stars](https://img.shields.io/github/stars/agentlas-ai/Agentlas-OS)
 - [Smithery CLI](https://github.com/smithery-ai/cli) - Install, manage, and develop MCP servers and skills.
 - `npx antigravity-awesome-skills` - One-command install for 900+ skills from [sickn33/antigravity-awesome-skills](https://github.com/sickn33/antigravity-awesome-skills).
 


### PR DESCRIPTION
## Summary

Adds Agentlas OS to CLIs & Package Managers using the existing one-line entry and star-badge format.

## Verification

- Rebuilt on current main
- Description is under 120 characters
- One README entry only
- git diff --check: passed

Disclosure: I am submitting this entry on behalf of the Agentlas project.