### PR TITLE
Add LLM Pulse MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ The [Model Context Protocol](https://modelcontextprotocol.io) (MCP) is an open s
 - [modelcontextprotocol/servers](https://github.com/modelcontextprotocol/servers) - Official reference MCP server implementations. ![GitHub stars](https://img.shields.io/github/stars/modelcontextprotocol/servers)
 - [Official MCP Registry](https://registry.modelcontextprotocol.io) - Authoritative registry with open API spec. ![GitHub stars](https://img.shields.io/github/stars/modelcontextprotocol/registry)
 
+### Domain-Specific
+
+- [LLM-Pulse/llmpulse-mcp](https://github.com/LLM-Pulse/llmpulse-mcp) - Hosted AI visibility analytics MCP for brand mentions, citations, sentiment, and share of voice. ![GitHub stars](https://img.shields.io/github/stars/LLM-Pulse/llmpulse-mcp)
+
 ### Awesome Lists
 
 - [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers) - THE dominant MCP list. 1,000+ entries. ![GitHub stars](https://img.shields.io/github/stars/punkpeye/awesome-mcp-servers)


### PR DESCRIPTION
## Summary\n- Add LLM Pulse's official hosted MCP server metadata repo to the MCP Servers section.\n\n## Validation\n- Content-only README entry.\n- Verified the source repo is https://github.com/LLM-Pulse/llmpulse-mcp and the hosted endpoint is documented there.\n