### PR TITLE
Add web-reverse-engineer project to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The [Agent Skills spec](https://github.com/anthropics/skills) is the emerging cr
 ### Domain-Specific
 
 - [K-Dense-AI/claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills) - Ready-to-use skills for research, science, engineering, analysis, finance and writing. ![GitHub stars](https://img.shields.io/github/stars/K-Dense-AI/claude-scientific-skills)
+- [uycung/web-reverse-engineer](https://github.com/uycung/web-reverse-engineer) - Clean-room SKILL.md workflow: study a public site's runtime behavior, motion, and interaction, then rebuild an original implementation. Not a clone tool. ![GitHub stars](https://img.shields.io/github/stars/uycung/web-reverse-engineer)
 
 ### Collections
 


### PR DESCRIPTION
Adds web-reverse-engineer, a portable SKILL.md workflow that teaches coding agents to study a public site's runtime behavior, motion, and interaction, then rebuild an original clean-room implementation. Not a clone/copy tool — no source, assets, or exact styling is copied. Works with Claude Code, Codex, Cursor, and Gemini CLI.

Repo: https://github.com/uycung/web-reverse-engineer
Live demos: https://web-reverse-engineer.netlify.app/