### PR TITLE
Add skillcraft to CLIs & Package Managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Command-line tools for installing and managing agent skills.
 - [agent-skills-cli](https://github.com/Karanjot786/agent-skills-cli) - Universal CLI. Access 40,000+ skills from SkillsMP. Syncs to Cursor, Claude Code, Copilot, Codex, Antigravity.
 - [Smithery CLI](https://github.com/smithery-ai/cli) - Install, manage, and develop MCP servers and skills.
 - `npx antigravity-awesome-skills` - One-command install for 900+ skills from [sickn33/antigravity-awesome-skills](https://github.com/sickn33/antigravity-awesome-skills).
-- [skillcraft](https://github.com/cloudroad-io/skillcraft) - Lint, sync, and scaffold SKILL.md / CLAUDE.md / AGENTS.md / .cursor rules / copilot-instructions. ![GitHub stars](https://img.shields.io/github/stars/cloudroad-io/skillcraft)
+- [skillcraft](https://github.com/dimanovikov/skillcraft) - Lint, sync, and scaffold SKILL.md / CLAUDE.md / AGENTS.md / .cursor rules / copilot-instructions. ![GitHub stars](https://img.shields.io/github/stars/dimanovikov/skillcraft)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ Command-line tools for installing and managing agent skills.
 - [agent-skills-cli](https://github.com/Karanjot786/agent-skills-cli) - Universal CLI. Access 40,000+ skills from SkillsMP. Syncs to Cursor, Claude Code, Copilot, Codex, Antigravity.
 - [Smithery CLI](https://github.com/smithery-ai/cli) - Install, manage, and develop MCP servers and skills.
 - `npx antigravity-awesome-skills` - One-command install for 900+ skills from [sickn33/antigravity-awesome-skills](https://github.com/sickn33/antigravity-awesome-skills).
+- [skillcraft](https://github.com/cloudroad-io/skillcraft) - Lint, sync, and scaffold SKILL.md / CLAUDE.md / AGENTS.md / .cursor rules / copilot-instructions. ![GitHub stars](https://img.shields.io/github/stars/cloudroad-io/skillcraft)
 
 ---
 


### PR DESCRIPTION
## skillcraft

A cross-format CLI for **agent-config files**: lint, sync, and scaffold `SKILL.md` / `CLAUDE.md` / `AGENTS.md` / `.cursor` rules / `copilot-instructions`. Author one canonical `AGENTS.md` and generate/sync the others; `sync --check` fails CI the moment a target drifts.

- **Repo:** https://github.com/dimanovikov/skillcraft
- **Install:** `pip install skillcraft`
- **License:** MIT · v0.1 published on PyPI · actively maintained

Placed under **CLIs & Package Managers** (command-line tooling for managing agent skills/configs), following the README format documented in `CONTRIBUTING.md` (`- [name](url) - Short description. ![GitHub stars](...)`).
