### PR TITLE
Add AgentServices — x402 paid data APIs with MCP server (37 tools, 54 services)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ The [Model Context Protocol](https://modelcontextprotocol.io) (MCP) is an open s
 - [esc5221/awesome-awesome-mcp-servers](https://github.com/esc5221/awesome-awesome-mcp-servers) - Meta-list of all awesome-mcp-servers lists.
 - [collabnix/awesome-mcp-lists](https://github.com/collabnix/awesome-mcp-lists) - Combined servers + clients + toolkits.
 
+### Commercial & Paid APIs
+
+- [vbkotecha/aiservices-api](https://github.com/vbkotecha/aiservices-api) - AgentServices — 54 x402-paid data APIs (crypto, stocks, FX, news) with MCP server (37 tools). ![GitHub stars](https://img.shields.io/github/stars/vbkotecha/aiservices-api)
+
 ---
 
 ## Cursor Rules


### PR DESCRIPTION
## What

Added [AgentServices](https://agentservices.to) under a new **Commercial & Paid APIs** subsection in MCP Servers.

## Why

AgentServices is a production data API platform with x402 nanopayments:
- **54 paid data APIs** — crypto market data, stocks, FX rates, news, onchain analytics
- **37 MCP tools** — full MCP server with streaming responses
- **Agent discovery** — `agents.json` at root for structured agent routing
- **Official MCP Registry** — listed at `to.agentservices/agentservices` (v5.3.0)
- **Glama** — listed at `glama.ai/mcp/servers/vbkotecha/aiservices-api`

Live at `https://agentservices.to` with OpenAPI spec at `/openapi.json`.

This is the first x402-paid entry in the directory. Created a new subsection since none of the existing MCP categories cover commercial/paid API servers.

## Format

Followed contributing guidelines: standard entry format with star badge.

```markdown
- [vbkotecha/aiservices-api](https://github.com/vbkotecha/aiservices-api) - AgentServices — 54 x402-paid data APIs (crypto, stocks, FX, news) with MCP server (37 tools). ![GitHub stars](https://img.shields.io/github/stars/vbkotecha/aiservices-api)
```