### PR TITLE
Add verify-done-skills (anti Fake Done)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,272 +1,1950 @@
-# Awesome Agent Skills [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
+<a href="https://github.com/VoltAgent/voltagent">
+     <img width="1500" alt="claude-skills" src="https://github.com/user-attachments/assets/0db54cfc-f3dd-4683-abbb-e4c01d9dfb5d" />
+</a>
 
-> A curated directory of skills, tools, and plugins for AI coding agents, across every platform.
 
-Unlike platform-specific lists, this directory covers **all** agent skill ecosystems in one place: Agent Skills (SKILL.md), MCP servers, Cursor rules, Windsurf rules, Gemini CLI extensions, Copilot extensions, OpenClaw skills, and more.
+<br/>
+<br/>
 
-**[Website](https://awesomeagentskills.dev)** · **[Submit a Skill](#contributing)** · **[Sync Status](#data-sources--sync)**
+<div align="center">
+    <strong>A collection of official Agent Skills from leading development teams and the community.
+    <br />
+    Hand-picked, not AI-slop generated.
+    </strong>
+    <br />
+    <br />
 
----
+</div>
 
-## Contents
+<div align="center">
 
-- [Agent Skills (SKILL.md)](#agent-skills-skillmd)
-- [MCP Servers](#mcp-servers)
-- [Cursor Rules](#cursor-rules)
-- [Windsurf Rules](#windsurf-rules)
-- [Gemini CLI Extensions](#gemini-cli-extensions)
-- [GitHub Copilot Extensions](#github-copilot-extensions)
-- [OpenClaw Skills](#openclaw-skills)
-- [LangChain Tools](#langchain-tools)
-- [CrewAI Tools](#crewai-tools)
-- [n8n Nodes](#n8n-nodes)
-- [Multi-Platform Collections](#multi-platform-collections)
-- [Directories & Marketplaces](#directories--marketplaces)
-- [CLIs & Package Managers](#clis--package-managers)
-- [Specs & Standards](#specs--standards)
-- [Data Sources & Sync](#data-sources--sync)
-- [Contributing](#contributing)
+[![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
+![Skills Count](https://img.shields.io/badge/Skills-1497+-blue?style=flat-square)
+![Last Update](https://img.shields.io/github/last-commit/VoltAgent/awesome-agent-skills?label=Last%20update&style=flat-square)
+<a href="https://github.com/VoltAgent/voltagent">
+  <img alt="VoltAgent" src="https://cdn.voltagent.dev/website/logo/logo-2-svg.svg" height="20" />
+</a>
+[![Discord](https://img.shields.io/discord/1361559153780195478.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://s.voltagent.dev/discord)
 
----
 
-## Agent Skills (SKILL.md)
+</div>
 
-The [Agent Skills spec](https://github.com/anthropics/skills) is the emerging cross-platform standard. Created by Anthropic, adopted by OpenAI (Codex CLI), Google (Gemini CLI), and others. Skills are defined via `SKILL.md` files with YAML frontmatter.
+</div>
 
-### Official & Reference
+# Awesome Agent Skills
 
-- [anthropics/skills](https://github.com/anthropics/skills) - Official Agent Skills spec + reference skills. ![GitHub stars](https://img.shields.io/github/stars/anthropics/skills)
-- [OpenAI Codex CLI Skills](https://developers.openai.com/codex/skills/) - Official Codex skills page (same SKILL.md format).
-- [agentskills.io](https://agentskills.io) - Community spec site covering cross-platform compatibility. ![GitHub stars](https://img.shields.io/github/stars/agentskills/agentskills)
+Unlike many bulk-generated skill repositories, this collection focuses on real-world Agent Skills created and used by actual engineering teams, not mass AI‑generated stuff.
 
-### Domain-Specific
+This collection features official skills published by leading development teams, including Anthropic, Google Labs, Vercel, Stripe, Cloudflare, Netlify, Trail of Bits, Sentry, Expo, Hugging Face, Figma, and more, alongside community-built skills.
 
-- [K-Dense-AI/claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills) - Ready-to-use skills for research, science, engineering, analysis, finance and writing. ![GitHub stars](https://img.shields.io/github/stars/K-Dense-AI/claude-scientific-skills)
+Compatible with Claude Code, Codex, Antigravity, Gemini CLI, Cursor, GitHub Copilot, OpenCode, Windsurf, and more. See the table below for paths and documentation.
 
-### Collections
+The most contributed Agent Skills repository, built and maintained together with the community.
 
-- [ComposioHQ/awesome-claude-skills](https://github.com/ComposioHQ/awesome-claude-skills) - Largest Claude skills list. ![GitHub stars](https://img.shields.io/github/stars/ComposioHQ/awesome-claude-skills)
-- [sickn33/antigravity-awesome-skills](https://github.com/sickn33/antigravity-awesome-skills) - 900+ installable skills. Cross-platform. `npx antigravity-awesome-skills` to install. ![GitHub stars](https://img.shields.io/github/stars/sickn33/antigravity-awesome-skills)
-- [VoltAgent/awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills) - 380+ skills for Claude Code, Codex, Antigravity, Gemini CLI, Cursor. ![GitHub stars](https://img.shields.io/github/stars/VoltAgent/awesome-agent-skills)
-- [travisvn/awesome-claude-skills](https://github.com/travisvn/awesome-claude-skills) - Claude Code workflow-focused skills. ![GitHub stars](https://img.shields.io/github/stars/travisvn/awesome-claude-skills)
-- [heilcheng/awesome-agent-skills](https://github.com/heilcheng/awesome-agent-skills) - Skills + tools + tutorials for Claude, Codex, Antigravity, Copilot. ![GitHub stars](https://img.shields.io/github/stars/heilcheng/awesome-agent-skills)
-- [skillmatic-ai/awesome-agent-skills](https://github.com/skillmatic-ai/awesome-agent-skills) - Architecture-focused skill resource. ![GitHub stars](https://img.shields.io/github/stars/skillmatic-ai/awesome-agent-skills)
-- [rohitg00/awesome-claude-code-toolkit](https://github.com/rohitg00/awesome-claude-code-toolkit) - 135 agents, 35 skills, 42 commands, 120 plugins, 19 hooks. ![GitHub stars](https://img.shields.io/github/stars/rohitg00/awesome-claude-code-toolkit)
 
-### Claude Code Ecosystem
+## 💛 Sponsors
 
-- [hesreallyhim/awesome-claude-code](https://github.com/hesreallyhim/awesome-claude-code) - Comprehensive Claude Code ecosystem: skills, hooks, slash-commands, plugins. ![GitHub stars](https://img.shields.io/github/stars/hesreallyhim/awesome-claude-code)
-- [jqueryscript/awesome-claude-code](https://github.com/jqueryscript/awesome-claude-code) - IDE integrations, frameworks, resources. ![GitHub stars](https://img.shields.io/github/stars/jqueryscript/awesome-claude-code)
+|  |  |
+| :-: | :-- |
+| <a href="https://www.testmuai.com"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.voltagent.dev/awesome-repo/testmui/testmuai-white.png"><img alt="TestMu AI" src="https://cdn.voltagent.dev/awesome-repo/testmui/testmuai-black.png" width="425"></picture></a> | [TestMu AI (formerly LambdaTest)](https://www.testmuai.com) is an AI-native testing cloud platform built for modern engineering teams. Covering everything from autonomous test creation and fast execution to testing AI agents, chatbots and voice assistants. |
+| <a href="https://zero.xyz"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.voltagent.dev/awesome-repo/zero-xyz/zero-dark.png"><img alt="Zero" src="https://cdn.voltagent.dev/awesome-repo/zero-xyz/zero-light.png" width="425"></picture></a> | [Zero](https://zero.xyz) gives your AI access to thousands of tools, APIs, and services, letting it go from prompt to project with no configuration. Instead of asking you to sign up or grab an API key, your AI discovers and uses whatever real service solves the problem right from chat. |
+| <a href="https://lite.ego.app/?utm_source=officialskills&utm_medium=sponsor&utm_campaign=github-sponsor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.voltagent.dev/awesome-repo/ego-lite/logo_wordmark_lite_white.svg"><img alt="Ego Lite" src="https://cdn.voltagent.dev/awesome-repo/ego-lite/logo_wordmark_lite_dark.svg" width="425"></picture></a> | [Ego Lite](https://lite.ego.app/?utm_source=officialskills&utm_medium=sponsor&utm_campaign=github-sponsor) is the fastest browser for your AI agents to run browser automation tasks, 3.45x faster than agent-browser (Vercel), always free, no setup, and lets your agents run 100+ browser tasks at the same time in their Spaces. |
 
----
+<br />
 
-## MCP Servers
+<a href="https://sponsors.voltagent.dev/#awesome-agent-skills"><img src="https://img.shields.io/badge/📩_Become_a_Sponsor-Contact_Us-blue?style=for-the-badge&logoColor=white" alt="Become a Sponsor" /></a>
 
-The [Model Context Protocol](https://modelcontextprotocol.io) (MCP) is an open standard for connecting AI models to data sources and tools. 17,000+ servers across directories.
 
-### Official
+## Table of Contents
+
+### Official Skills by
+
+| | | | | 
+|---|---|---|---|
+| [Claude](#official-claude-skills) | [VoltAgent](#skills-by-voltagent) | [TestMu AI](#skills-by-testmu-ai) | [Zero](#skills-by-zero) |
+| [Angular](#skills-by-angular) | [Composio](#skills-by-composio-team) | [Supabase](#skills-by-supabase-team) | [Google Gemini](#skills-by-google-gemini) |
+| [Stripe](#skills-by-stripe-team) | [Courier](#skills-by-courier) | [CallStack](#skills-by-callstack) | [Expo](#skills-by-expo-team) |
+| [Better Auth](#skills-by-better-auth-team) | [Tinybird](#skills-by-tinybird-team) | [HashiCorp](#skills-by-hashicorp-team-for-terraform) | [Sanity](#skills-by-sanity-team) |
+| [Firecrawl](#skills-by-firecrawl-team) | [Neon](#skills-by-neon-team) | [ClickHouse](#skill-by-clickhouse) | [Remotion](#skills-by-remotion) |
+| [Replicate](#skills-by-replicate) | [Typefully](#skills-by-typefully) | [Vercel](#skills-by-vercel-engineering-team) | [Cloudflare](#skills-by-cloudflare-team) |
+| [Netlify](#skills-by-netlify-team) | [Google Labs (Stitch)](#skills-by-google-labs-stitch) | [Google Workspace CLI](#skills-by-google-workspace-cli) | [Hugging Face](#skills-by-hugging-face-team) |
+| [Trail of Bits](#security-skills-by-trail-of-bits-team) | [Sentry](#skills-by-sentry-team-for-their-dev-team) | [Microsoft](#skills-by-microsoft) | [fal.ai](#skills-by-falai-team) |
+| [WordPress](#skills-by-wordpress-development-team) | [OpenAI](#skills-by-openai) | [Figma](#skills-by-figma) | [Corey Haines](#marketing-skills-by-corey-haines) |
+| [Binance](#skills-by-binance) | [Dean Peters](#product-manager-skills-by-dean-peters) | [Paweł Huryn](#product-management-skills-by-pawel-huryn) | [MiniMax](#skills-by-minimax-team) |
+| [DuckDB](#skills-by-duckdb) | [GSAP](#skills-by-gsap-greensock) | [Garry Tan (gstack)](#skills-by-garry-tan-gstack) | [Notion](#skills-by-notion) |
+| [Resend](#skills-by-resend) | [Addy Osmani (Web Quality)](#skills-by-addy-osmani-web-quality) | [MongoDB](#skills-by-mongodb) | [Kim Barrett (Advertising)](#advertising-skills-by-kim-barrett) |
+| [Apollo GraphQL](#skills-by-apollo-graphql) | [Auth0](#skills-by-auth0) | [Brave](#skills-by-brave) | [Browserbase](#skills-by-browserbase) |
+| [CodeRabbit](#skills-by-coderabbit) | [Coinbase](#skills-by-coinbase) | [Datadog Labs](#skills-by-datadog-labs) | [Firebase](#skills-by-firebase) |
+| [Flutter](#skills-by-flutter) | [Venice.ai](#skills-by-veniceai) | [Red Hat](#skills-by-redhat) | [Community](#community-skills) |
+| [Redis](#skills-by-redis) | [NVIDIA](#skills-by-nvidia) | [Google Cloud](#skills-by-google-cloud) | [Quality Standards](#skill-quality-standards) |
+
+
+<br/>
+
+<br/>
+
+<a href="https://launchkit.getdesign.md/">
+<img src="https://cdn.voltagent.dev/awesome-repo/launchkit-banner-3.png" alt="launchkit"  /><br/>
+</a>
+
+<br/>
+
+
+<br/>
+
+<details open>
+<summary><h3 style="display:inline">Official Claude Skills</h3></summary>
+
+- **[anthropics/docx](https://officialskills.sh/anthropics/skills/docx)** - Create, edit, and analyze Word documents
+- **[anthropics/doc-coauthoring](https://officialskills.sh/anthropics/skills/doc-coauthoring)** - Collaborative document editing and co-authoring
+- **[anthropics/pptx](https://officialskills.sh/anthropics/skills/pptx)** - Create, edit, and analyze PowerPoint presentations
+- **[anthropics/xlsx](https://officialskills.sh/anthropics/skills/xlsx)** - Create, edit, and analyze Excel spreadsheets
+- **[anthropics/pdf](https://officialskills.sh/anthropics/skills/pdf)** - Extract text, create PDFs, and handle forms
+- **[anthropics/algorithmic-art](https://officialskills.sh/anthropics/skills/algorithmic-art)** - Create generative art using p5.js with seeded randomness
+- **[anthropics/canvas-design](https://officialskills.sh/anthropics/skills/canvas-design)** - Design visual art in PNG and PDF formats
+- **[anthropics/frontend-design](https://officialskills.sh/anthropics/skills/frontend-design)** - Frontend design and UI/UX development tools
+- **[anthropics/slack-gif-creator](https://officialskills.sh/anthropics/skills/slack-gif-creator)** - Create animated GIFs optimized for Slack size constraints
+- **[anthropics/theme-factory](https://officialskills.sh/anthropics/skills/theme-factory)** - Style artifacts with professional themes or generate custom themes
+- **[anthropics/web-artifacts-builder](https://officialskills.sh/anthropics/skills/web-artifacts-builder)** - Build complex claude.ai HTML artifacts with React and Tailwind
+- **[anthropics/mcp-builder](https://officialskills.sh/anthropics/skills/mcp-builder)** - Create MCP servers to integrate external APIs and services
+- **[anthropics/webapp-testing](https://officialskills.sh/anthropics/skills/webapp-testing)** - Test local web applications using Playwright
+- **[anthropics/brand-guidelines](https://officialskills.sh/anthropics/skills/brand-guidelines)** - Apply Anthropic's brand colors and typography to artifacts
+- **[anthropics/internal-comms](https://officialskills.sh/anthropics/skills/internal-comms)** - Write status reports, newsletters, and FAQs
+- **[anthropics/skill-creator](https://officialskills.sh/anthropics/skills/skill-creator)** - Guide for creating skills that extend Claude's capabilities
+- **[anthropics/template](https://officialskills.sh/anthropics/skills/template)** - Basic template for creating new skills
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Skills by VoltAgent</h3></summary>
+
+Official skills by VoltAgent for building AI agents with the VoltAgent TypeScript framework.
+- **[voltagent/create-voltagent](https://officialskills.sh/voltagent/skills/create-voltagent)** - Project setup guide with CLI and manual steps
+- **[voltagent/voltagent-best-practices](https://officialskills.sh/voltagent/skills/voltagent-best-practices)** - Architecture and usage patterns for agents, workflows, memory, and servers
+- **[voltagent/voltagent-core-reference](https://officialskills.sh/voltagent/skills/voltagent-core-reference)** - Reference for the VoltAgent class options and lifecycle methods
+- **[voltagent/voltagent-docs-bundle](https://officialskills.sh/voltagent/skills/voltagent-docs-bundle)** - Lookup embedded docs from @voltagent/core for version-matched documentation
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Skills by TestMu AI</h3></summary>
+
+Production-grade Agent Skills for every major test automation framework, maintained by the TestMu AI (formerly LambdaTest) team. They help AI coding assistants generate expert-level test automation code across web, mobile, API, BDD, and unit testing stacks.
+
+- **[testmu-ai/api-skill](https://github.com/LambdaTest/agent-skills/tree/main/api-skill)** - Suite of API skills for designing, mocking, documenting, securing, and generating tests for REST/GraphQL/gRPC APIs
+- **[testmu-ai/appium-skill](https://github.com/LambdaTest/agent-skills/tree/main/appium-skill)** - Generate Appium mobile automation for Android and iOS in Java, Python, or JS
+- **[testmu-ai/behat-skill](https://github.com/LambdaTest/agent-skills/tree/main/behat-skill)** - Generate Behat BDD tests for PHP with Gherkin and Mink
+- **[testmu-ai/behave-skill](https://github.com/LambdaTest/agent-skills/tree/main/behave-skill)** - Generate Behave BDD tests for Python with Gherkin and step implementations
+- **[testmu-ai/capybara-skill](https://github.com/LambdaTest/agent-skills/tree/main/capybara-skill)** - Generate Capybara E2E tests in Ruby with RSpec integration
+- **[testmu-ai/cicd-pipeline-skill](https://github.com/LambdaTest/agent-skills/tree/main/cicd-pipeline-skill)** - Generate CI/CD pipelines for tests on GitHub Actions, Jenkins, GitLab CI, and Azure DevOps
+- **[testmu-ai/codeception-skill](https://github.com/LambdaTest/agent-skills/tree/main/codeception-skill)** - Generate Codeception acceptance, functional, and unit tests in PHP
+- **[testmu-ai/cucumber-skill](https://github.com/LambdaTest/agent-skills/tree/main/cucumber-skill)** - Generate Cucumber BDD tests with Gherkin and step definitions in Java, JS, or Ruby
+- **[testmu-ai/cypress-skill](https://github.com/LambdaTest/agent-skills/tree/main/cypress-skill)** - Generate Cypress E2E and component tests in JavaScript or TypeScript
+- **[testmu-ai/detox-skill](https://github.com/LambdaTest/agent-skills/tree/main/detox-skill)** - Generate Detox gray-box E2E tests for React Native apps in JavaScript
+- **[testmu-ai/espresso-skill](https://github.com/LambdaTest/agent-skills/tree/main/espresso-skill)** - Generate Espresso UI tests for Android apps in Kotlin or Java
+- **[testmu-ai/flutter-testing-skill](https://github.com/LambdaTest/agent-skills/tree/main/flutter-testing-skill)** - Generate Flutter widget, integration, and golden tests in Dart
+- **[testmu-ai/gauge-skill](https://github.com/LambdaTest/agent-skills/tree/main/gauge-skill)** - Generate Gauge specs in Markdown with steps in Java, Python, JS, or Ruby
+- **[testmu-ai/geb-skill](https://github.com/LambdaTest/agent-skills/tree/main/geb-skill)** - Generate Geb browser automation in Groovy with Spock and page objects
+- **[testmu-ai/hyperexecute-skill](https://github.com/LambdaTest/agent-skills/tree/main/hyperexecute-skill)** - Operate TestMu AI HyperExecute end-to-end: YAML, CLI runs, debugging, and CI wiring
+- **[testmu-ai/jasmine-skill](https://github.com/LambdaTest/agent-skills/tree/main/jasmine-skill)** - Generate Jasmine BDD tests in JavaScript with spies and async support
+- **[testmu-ai/jest-skill](https://github.com/LambdaTest/agent-skills/tree/main/jest-skill)** - Generate Jest unit and integration tests in JS/TS with mocking and snapshots
+- **[testmu-ai/junit-5-skill](https://github.com/LambdaTest/agent-skills/tree/main/junit-5-skill)** - Generate JUnit 5 unit and integration tests in Java with Mockito
+- **[testmu-ai/karma-skill](https://github.com/LambdaTest/agent-skills/tree/main/karma-skill)** - Generate Karma test-runner configs for browser-based JS testing
+- **[testmu-ai/laravel-dusk-skill](https://github.com/LambdaTest/agent-skills/tree/main/laravel-dusk-skill)** - Generate Laravel Dusk Chrome-based browser tests in PHP
+- **[testmu-ai/lettuce-skill](https://github.com/LambdaTest/agent-skills/tree/main/lettuce-skill)** - Generate Lettuce BDD tests for Python (legacy; prefer Behave)
+- **[testmu-ai/mocha-skill](https://github.com/LambdaTest/agent-skills/tree/main/mocha-skill)** - Generate Mocha tests in JavaScript with Chai and Sinon
+- **[testmu-ai/mstest-skill](https://github.com/LambdaTest/agent-skills/tree/main/mstest-skill)** - Generate MSTest tests in C# for .NET
+- **[testmu-ai/nemojs-skill](https://github.com/LambdaTest/agent-skills/tree/main/nemojs-skill)** - Generate Nemo.js Selenium-based tests for Node.js
+- **[testmu-ai/nightwatchjs-skill](https://github.com/LambdaTest/agent-skills/tree/main/nightwatchjs-skill)** - Generate NightwatchJS E2E tests in JavaScript with Selenium WebDriver
+- **[testmu-ai/nunit-skill](https://github.com/LambdaTest/agent-skills/tree/main/nunit-skill)** - Generate NUnit 3 tests in C# with the constraint model and Moq
+- **[testmu-ai/phpunit-skill](https://github.com/LambdaTest/agent-skills/tree/main/phpunit-skill)** - Generate PHPUnit tests in PHP with data providers and mocking
+- **[testmu-ai/playwright-skill](https://github.com/LambdaTest/agent-skills/tree/main/playwright-skill)** - Generate Playwright E2E tests in TS, JS, Python, Java, or C#
+- **[testmu-ai/protractor-skill](https://github.com/LambdaTest/agent-skills/tree/main/protractor-skill)** - Generate Protractor E2E tests for Angular in JS/TS (deprecated; prefer Playwright/Cypress)
+- **[testmu-ai/puppeteer-skill](https://github.com/LambdaTest/agent-skills/tree/main/puppeteer-skill)** - Generate Puppeteer scripts for browser automation, scraping, and PDF generation
+- **[testmu-ai/pytest-skill](https://github.com/LambdaTest/agent-skills/tree/main/pytest-skill)** - Generate pytest tests in Python with fixtures, parametrize, and mocking
+- **[testmu-ai/reqnroll-skill](https://github.com/LambdaTest/agent-skills/tree/main/reqnroll-skill)** - Generate Reqnroll BDD tests for web and mobile in C#
+- **[testmu-ai/robot-framework-skill](https://github.com/LambdaTest/agent-skills/tree/main/robot-framework-skill)** - Generate Robot Framework keyword-driven tests in Python
+- **[testmu-ai/rspec-skill](https://github.com/LambdaTest/agent-skills/tree/main/rspec-skill)** - Generate RSpec tests in Ruby with matchers, hooks, and mocking
+- **[testmu-ai/selenide-skill](https://github.com/LambdaTest/agent-skills/tree/main/selenide-skill)** - Generate Selenide UI tests in Java with auto-waits and a fluent API
+- **[testmu-ai/selenium-skill](https://github.com/LambdaTest/agent-skills/tree/main/selenium-skill)** - Generate Selenium WebDriver tests in Java, Python, JS, C#, Ruby, or PHP
+- **[testmu-ai/serenity-bdd-skill](https://github.com/LambdaTest/agent-skills/tree/main/serenity-bdd-skill)** - Generate Serenity BDD tests in Java with the Screenplay pattern and reporting
+- **[testmu-ai/smartui-skill](https://github.com/LambdaTest/agent-skills/tree/main/smartui-skill)** - Generate SmartUI visual regression configs for screenshot comparison
+- **[testmu-ai/specflow-skill](https://github.com/LambdaTest/agent-skills/tree/main/specflow-skill)** - Generate SpecFlow BDD tests for C#/.NET with Gherkin and step bindings
+- **[testmu-ai/test-framework-migration-skill](https://github.com/LambdaTest/agent-skills/tree/main/test-framework-migration-skill)** - Migrate tests between Selenium, Playwright, Puppeteer, and Cypress
+- **[testmu-ai/testcafe-skill](https://github.com/LambdaTest/agent-skills/tree/main/testcafe-skill)** - Generate TestCafe automation tests in JavaScript or TypeScript
+- **[testmu-ai/testng-skill](https://github.com/LambdaTest/agent-skills/tree/main/testng-skill)** - Generate TestNG tests in Java with data providers and parallel execution
+- **[testmu-ai/testunit-skill](https://github.com/LambdaTest/agent-skills/tree/main/testunit-skill)** - Generate Test::Unit xUnit-style tests in Ruby
+- **[testmu-ai/unittest-skill](https://github.com/LambdaTest/agent-skills/tree/main/unittest-skill)** - Generate Python unittest tests with TestCase and setUp/tearDown
+- **[testmu-ai/vitest-skill](https://github.com/LambdaTest/agent-skills/tree/main/vitest-skill)** - Generate Vitest tests in JS/TS with a Jest-compatible API and ESM
+- **[testmu-ai/webdriverio-skill](https://github.com/LambdaTest/agent-skills/tree/main/webdriverio-skill)** - Generate WebdriverIO (WDIO) automation tests in JavaScript or TypeScript
+- **[testmu-ai/xcuitest-skill](https://github.com/LambdaTest/agent-skills/tree/main/xcuitest-skill)** - Generate XCUITest UI tests for iOS/iPadOS apps in Swift
+- **[testmu-ai/xunit-skill](https://github.com/LambdaTest/agent-skills/tree/main/xunit-skill)** - Generate xUnit.net tests in C# with Fact/Theory and FluentAssertions
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Skills by Zero</h3></summary>
+
+
+- **[zero/zero](https://github.com/officialzeroxyz/zero-plugins/blob/main/plugins/zero/skills/zero/SKILL.md)** - Discover and call external paid tools for Claude Code agents instead of stopping to ask the user to sign up or fetch an API key
+- **[zero/zero-gemini](https://github.com/officialzeroxyz/zero-plugins/tree/main/plugins/zero-gemini)** - Same Zero tool-discovery and payment layer packaged as a Gemini CLI extension
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Skills by Angular</h3></summary>
+
+- **[angular/angular-developer](https://github.com/angular/skills)** - Generate Angular code and architectural guidance for components, services, reactivity
+- **[angular/angular-new-app](https://github.com/angular/skills)** - Create new Angular apps using CLI with modern best practices
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Skills by Composio Team</h3></summary>
+
+- **[composiohq/composio](https://officialskills.sh/composiohq/skills/composio)** - Connect AI agents to 1000+ external apps with managed authentication
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Skills by Supabase Team</h3></summary>
+
+- **[supabase/postgres-best-practices](https://officialskills.sh/supabase/skills/postgres-best-practices)** - PostgreSQL best practices for Supabase
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Skills by Google Gemini</h3></summary>
+
+- **[google-gemini/gemini-api-dev](https://officialskills.sh/google-gemini/skills/gemini-api-dev)** - Best practices for developing Gemini-powered apps using the Gemini API
+- **[google-gemini/vertex-ai-api-dev](https://officialskills.sh/google-gemini/skills/vertex-ai-api-dev)** - Developing Gemini-powered apps on Google Cloud Vertex AI using the Gen AI SDK
+- **[google-gemini/gemini-live-api-dev](https://officialskills.sh/google-gemini/skills/gemini-live-api-dev)** - Building real-time bidirectional streaming apps with the Gemini Live API
+- **[google-gemini/gemini-interactions-api](https://officialskills.sh/google-gemini/skills/gemini-interactions-api)** - Building apps with the Gemini Interactions API for text, chat, streaming, and image generation
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Skills by Stripe Team</h3></summary>
+
+- **[stripe/stripe-best-practices](https://officialskills.sh/stripe/skills/stripe-best-practices)** - Best practices for building Stripe integrations
+- **[stripe/upgrade-stripe](https://officialskills.sh/stripe/skills/upgrade-stripe)** - Upgrade Stripe SDK and API versions
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Skills by Courier</h3></summary>
+
+- **[trycourier/courier-skills](https://github.com/trycourier/courier-skills)** - Multi-channel notifications via email, SMS, push, and chat
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Skills by CallStack</h3></summary>
+
+- **[callstackincubator/react-native-best-practices](https://officialskills.sh/callstackincubator/skills/react-native-best-practices)** - Performance optimization for React Native apps from Callstack
+- **[callstackincubator/github](https://officialskills.sh/callstackincubator/skills/github)** - GitHub workflow patterns for PRs, code review, branching
+- **[callstackincubator/upgrading-react-native](https://officialskills.sh/callstackincubator/skills/upgrading-react-native)** - React Native upgrade workflow: templates, dependencies, and common pitfalls
+
+</details>
 
-- [modelcontextprotocol/servers](https://github.com/modelcontextprotocol/servers) - Official reference MCP server implementations. ![GitHub stars](https://img.shields.io/github/stars/modelcontextprotocol/servers)
-- [Official MCP Registry](https://registry.modelcontextprotocol.io) - Authoritative registry with open API spec. ![GitHub stars](https://img.shields.io/github/stars/modelcontextprotocol/registry)
+<details>
+<summary><h3 style="display:inline">Skills by Better Auth Team</h3></summary>
 
-### Awesome Lists
+- **[better-auth/best-practices](https://officialskills.sh/better-auth/skills/best-practices)** - Best practices for Better Auth integration
+- **[better-auth/explain-error](https://officialskills.sh/better-auth/skills/explain-error)** - Explain Better Auth error messages
+- **[better-auth/providers](https://officialskills.sh/better-auth/skills/providers)** - Better Auth authentication providers
+- **[better-auth/create-auth](https://officialskills.sh/better-auth/skills/create-auth)** - Create authentication setup with Better Auth
+- **[better-auth/emailAndPassword](https://officialskills.sh/better-auth/skills/emailAndPassword)** - Email and password authentication with Better Auth
+- **[better-auth/organization](https://officialskills.sh/better-auth/skills/organization)** - Organization management with Better Auth
+- **[better-auth/twoFactor](https://officialskills.sh/better-auth/skills/twoFactor)** - Two-factor authentication with Better Auth
 
-- [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers) - THE dominant MCP list. 1,000+ entries. ![GitHub stars](https://img.shields.io/github/stars/punkpeye/awesome-mcp-servers)
-- [appcypher/awesome-mcp-servers](https://github.com/appcypher/awesome-mcp-servers) - Second largest, well-organized by category. ![GitHub stars](https://img.shields.io/github/stars/appcypher/awesome-mcp-servers)
-- [wong2/awesome-mcp-servers](https://github.com/wong2/awesome-mcp-servers) - Original early MCP list. ![GitHub stars](https://img.shields.io/github/stars/wong2/awesome-mcp-servers)
-- [rohitg00/awesome-devops-mcp-servers](https://github.com/rohitg00/awesome-devops-mcp-servers) - DevOps-focused MCP servers. ![GitHub stars](https://img.shields.io/github/stars/rohitg00/awesome-devops-mcp-servers)
-- [punkpeye/awesome-mcp-clients](https://github.com/punkpeye/awesome-mcp-clients) - MCP clients (complementary). ![GitHub stars](https://img.shields.io/github/stars/punkpeye/awesome-mcp-clients)
-- [punkpeye/awesome-mcp-devtools](https://github.com/punkpeye/awesome-mcp-devtools) - MCP development tools, SDKs, testing. ![GitHub stars](https://img.shields.io/github/stars/punkpeye/awesome-mcp-devtools)
-- [toolsdk-ai/toolsdk-mcp-registry](https://github.com/toolsdk-ai/toolsdk-mcp-registry) - Machine-readable JSON registry with OAuth2.1. ![GitHub stars](https://img.shields.io/github/stars/toolsdk-ai/toolsdk-mcp-registry)
+</details>
 
-### Meta
+<details>
+<summary><h3 style="display:inline">Skills by Tinybird Team</h3></summary>
 
-- [esc5221/awesome-awesome-mcp-servers](https://github.com/esc5221/awesome-awesome-mcp-servers) - Meta-list of all awesome-mcp-servers lists.
-- [collabnix/awesome-mcp-lists](https://github.com/collabnix/awesome-mcp-lists) - Combined servers + clients + toolkits.
-
----
-
-## Cursor Rules
-
-Rules that configure AI behavior in [Cursor](https://cursor.com) editor. Two formats: legacy `.cursorrules` and new `.mdc` (Markdown Directives).
-
-- [PatrickJS/awesome-cursorrules](https://github.com/PatrickJS/awesome-cursorrules) - THE dominant cursor rules collection. 500+ rules. ![GitHub stars](https://img.shields.io/github/stars/PatrickJS/awesome-cursorrules)
-- [cursor.directory](https://cursor.directory) - Community site with 1,000+ rules. 250K+ monthly users. 63K+ members.
-- [pontusab/cursor.directory](https://github.com/pontusab/cursor.directory) - Open source codebase powering cursor.directory. ![GitHub stars](https://img.shields.io/github/stars/pontusab/cursor.directory)
-- [sanjeed5/awesome-cursor-rules-mdc](https://github.com/sanjeed5/awesome-cursor-rules-mdc) - New .mdc format rules (replaces deprecated .cursorrules). ![GitHub stars](https://img.shields.io/github/stars/sanjeed5/awesome-cursor-rules-mdc)
-
----
-
-## Windsurf Rules
-
-Rules for the [Windsurf](https://windsurf.com) AI editor (formerly Codeium). Uses `.windsurfrules` and `global_rules.md`.
-
-- [Windsurf Official Directory](https://windsurf.com/editor/directory) - Official rules directory curated by Windsurf team.
-- [ichoosetoaccept/awesome-windsurf](https://github.com/ichoosetoaccept/awesome-windsurf) - Resources, rules, memories for Windsurf. ![GitHub stars](https://img.shields.io/github/stars/ichoosetoaccept/awesome-windsurf)
-- [SchneiderSam/awesome-windsurfrules](https://github.com/SchneiderSam/awesome-windsurfrules) - Windsurf global_rules and .windsurfrules files. ![GitHub stars](https://img.shields.io/github/stars/SchneiderSam/awesome-windsurfrules)
-
----
-
-## Gemini CLI Extensions
-
-Extensions and skills for [Google Gemini CLI](https://github.com/google-gemini/gemini-cli). Supports Agent Skills (SKILL.md) + native extensions + MCP.
-
-- [google-gemini/gemini-cli](https://github.com/google-gemini/gemini-cli) - Official Gemini CLI repo. ![GitHub stars](https://img.shields.io/github/stars/google-gemini/gemini-cli)
-- [Gemini CLI Extension Gallery](https://geminicli.com/extensions/) - Browse and discover extensions.
-- [Piebald-AI/awesome-gemini-cli](https://github.com/Piebald-AI/awesome-gemini-cli) - Curated tools, extensions, resources. ![GitHub stars](https://img.shields.io/github/stars/Piebald-AI/awesome-gemini-cli)
-- [gemini-cli-extensions](https://github.com/gemini-cli-extensions) - Community extensions GitHub org.
-- [intellectronica/gemini-cli-skillz](https://github.com/intellectronica/gemini-cli-skillz) - Anthropic-style Agent Skills via skillz MCP server.
-
----
-
-## GitHub Copilot Extensions
-
-Extensions for [GitHub Copilot](https://github.com/features/copilot) — agents, instructions, hooks, skills, plugins.
-
-- [github/awesome-copilot](https://github.com/github/awesome-copilot) - OFFICIAL GitHub repo. ![GitHub stars](https://img.shields.io/github/stars/github/awesome-copilot)
-- [GitHub Marketplace (Copilot Apps)](https://github.com/marketplace?type=apps&copilot_app=true) - Official Copilot extension marketplace.
-- [Copilot Extensions](https://github.com/features/copilot/extensions) - Extension capabilities overview.
-
----
-
-## OpenClaw Skills
-
-Skills for the [OpenClaw](https://openclaw.ai) multi-agent system. 5,700+ skills in the registry.
-
-- [VoltAgent/awesome-openclaw-skills](https://github.com/VoltAgent/awesome-openclaw-skills) - Main OpenClaw skills directory. ![GitHub stars](https://img.shields.io/github/stars/VoltAgent/awesome-openclaw-skills)
-- [ClawHub Registry](https://docs.openclaw.ai/tools/skills) - Official OpenClaw skills marketplace with version management.
-- [BankrBot/openclaw-skills](https://github.com/BankrBot/openclaw-skills) - Crypto, DeFi, Polymarket, automation skills. ![GitHub stars](https://img.shields.io/github/stars/BankrBot/openclaw-skills)
-- [openclawskills.net](https://openclawskills.net) - Web directory for OpenClaw skills.
-
----
-
-## LangChain Tools
-
-Tools and integrations for the [LangChain](https://python.langchain.com/) framework. 1,000+ integrations.
-
-- [langchain-ai/langchain](https://github.com/langchain-ai/langchain) - Core framework. ![GitHub stars](https://img.shields.io/github/stars/langchain-ai/langchain)
-- [LangChain Integrations](https://python.langchain.com/docs/integrations/tools/) - Official integrations directory (1,000+).
-- [kyrolabs/awesome-langchain](https://github.com/kyrolabs/awesome-langchain) - Awesome list for LangChain tools and projects. ![GitHub stars](https://img.shields.io/github/stars/kyrolabs/awesome-langchain)
-
----
-
-## CrewAI Tools
-
-Tools for the [CrewAI](https://crewai.com) agent framework. Now supports MCP integration.
-
-- [crewAIInc/crewAI-tools](https://github.com/crewAIInc/crewAI-tools) - Official CrewAI tools. 30+ built-in. ![GitHub stars](https://img.shields.io/github/stars/crewAIInc/crewAI-tools)
-- [crewAIInc/awesome-crewai](https://github.com/crewAIInc/awesome-crewai) - Official awesome list. ![GitHub stars](https://img.shields.io/github/stars/crewAIInc/awesome-crewai)
-- [CrewAI Tools Docs](https://docs.crewai.com/en/concepts/tools) - Official tool documentation.
-
----
-
-## n8n Nodes
-
-Workflow automation nodes for [n8n](https://n8n.io). 400+ integrations with native AI agent capabilities.
-
-- [n8n-io/n8n](https://github.com/n8n-io/n8n) - Core platform. ![GitHub stars](https://img.shields.io/github/stars/n8n-io/n8n)
-- [n8n Community Nodes](https://n8n.io/integrations/) - Official integrations directory (400+ nodes, 600+ templates).
-
----
-
-## Multi-Platform Collections
-
-Resources covering multiple agent platforms and ecosystems.
-
-- [Shubhamsaboo/awesome-llm-apps](https://github.com/Shubhamsaboo/awesome-llm-apps) - LLM apps with AI Agents, RAG, MCP, Voice Agents. ![GitHub stars](https://img.shields.io/github/stars/Shubhamsaboo/awesome-llm-apps)
-- [e2b-dev/awesome-ai-agents](https://github.com/e2b-dev/awesome-ai-agents) - THE original awesome-ai-agents list. ![GitHub stars](https://img.shields.io/github/stars/e2b-dev/awesome-ai-agents)
-- [Significant-Gravitas/AutoGPT](https://github.com/Significant-Gravitas/AutoGPT) - AutoGPT core with Components system. ![GitHub stars](https://img.shields.io/github/stars/Significant-Gravitas/AutoGPT)
-- [jim-schwoebel/awesome_ai_agents](https://github.com/jim-schwoebel/awesome_ai_agents) - 1,500+ agents catalogued. ![GitHub stars](https://img.shields.io/github/stars/jim-schwoebel/awesome_ai_agents)
-- [kyrolabs/awesome-agents](https://github.com/kyrolabs/awesome-agents) - Open-source AI agent tools and products. ![GitHub stars](https://img.shields.io/github/stars/kyrolabs/awesome-agents)
-
----
-
-## Directories & Marketplaces
-
-Web-based platforms for discovering and installing agent skills and tools.
-
-| Platform | Focus | Size | Open Source |
-|----------|-------|------|-------------|
-| [SkillsMP](https://skillsmp.com) | Agent Skills marketplace | 66,500+ | No |
-| [MCP.so](https://mcp.so) | MCP server directory | 17,900+ | [Yes](https://github.com/chatmcp/mcpso) |
-| [Glama](https://glama.ai/mcp/servers) | Hosted MCP servers | 17,800+ | No |
-| [PulseMCP](https://www.pulsemcp.com/servers) | MCP directory (Steering Committee) | 8,600+ | No |
-| [ClawHub](https://docs.openclaw.ai/tools/skills) | OpenClaw skills registry | 5,700+ | No |
-| [Smithery](https://smithery.ai) | MCP marketplace + CLI | 4,000+ | [Partial](https://github.com/smithery-ai) |
-| [cursor.directory](https://cursor.directory) | Cursor + Windsurf rules | 1,000+ | [Yes](https://github.com/pontusab/cursor.directory) |
-| [Composio](https://composio.dev) | Multi-framework integrations | 1,000+ | [Yes](https://github.com/ComposioHQ/composio) |
-| [MCPServers.org](https://mcpservers.org) | Curated MCP collection | Growing | No |
-| [Gemini Extension Gallery](https://geminicli.com/extensions/) | Gemini CLI extensions | Growing | No |
-| [GitHub Copilot Marketplace](https://github.com/marketplace?type=apps&copilot_app=true) | Copilot extensions | ~30 | No |
-| [LobeHub MCP](https://lobehub.com/mcp) | LobeChat MCP marketplace | Growing | Partial |
-
----
-
-## CLIs & Package Managers
-
-Command-line tools for installing and managing agent skills.
-
-- [agent-skills-cli](https://github.com/Karanjot786/agent-skills-cli) - Universal CLI. Access 40,000+ skills from SkillsMP. Syncs to Cursor, Claude Code, Copilot, Codex, Antigravity.
-- [Smithery CLI](https://github.com/smithery-ai/cli) - Install, manage, and develop MCP servers and skills.
-- `npx antigravity-awesome-skills` - One-command install for 900+ skills from [sickn33/antigravity-awesome-skills](https://github.com/sickn33/antigravity-awesome-skills).
-
----
-
-## Specs & Standards
-
-The specifications and standards that define agent skill formats.
-
-| Standard | Maintainer | Format | Platforms |
-|----------|-----------|--------|-----------|
-| [Agent Skills (SKILL.md)](https://github.com/anthropics/skills) | Anthropic | YAML frontmatter + Markdown | Claude Code, Codex CLI, Gemini CLI, Antigravity, Copilot |
-| [MCP](https://modelcontextprotocol.io) | Agentic AI Foundation | JSON-RPC over stdio/SSE | Universal (all major AI tools) |
-| [Cursor Rules](https://docs.cursor.com/context/rules) | Cursor | `.mdc` / `.cursorrules` | Cursor |
-| [Windsurf Rules](https://windsurf.com/editor/directory) | Windsurf | `.windsurfrules` | Windsurf |
-| [Gemini Extensions](https://google-gemini.github.io/gemini-cli/docs/extensions/) | Google | TypeScript modules | Gemini CLI |
-| [Copilot Extensions](https://github.com/features/copilot/extensions) | GitHub | GitHub Apps API | GitHub Copilot |
-
----
-
-## Data Sources & Sync
-
-This directory is automatically updated from multiple sources. See [SYNC.md](SYNC.md) for details on our data pipeline.
-
-| Source | Type | Sync Method | Frequency |
-|--------|------|-------------|-----------|
-| GitHub awesome-lists | Markdown parsing | GitHub API | Daily |
-| Official MCP Registry | REST API | API polling | Daily |
-| MCP.so | Supabase DB | API/scrape | Weekly |
-| SkillsMP | Web marketplace | API | Weekly |
-| cursor.directory | Open source repo | Git sync | Daily |
-| GitHub trending | GitHub API | API polling | Daily |
-
----
-
-## Contributing
-
-Contributions welcome! Please read [CONTRIBUTING.md](CONTRIBUTING.md) first.
-
-### How to submit a skill
-
-1. Fork this repo
-2. Add your skill to the appropriate section in `README.md`
-3. Follow the format: `- [name](url) - Short description. ![GitHub stars](https://img.shields.io/github/stars/owner/repo)`
-4. Submit a PR
-
-### What counts as an "agent skill"?
-
-Any tool, plugin, extension, rule set, or capability that enhances an AI coding agent's abilities. This includes:
-- SKILL.md files (Agent Skills spec)
-- MCP servers
-- Cursor/Windsurf rules
-- Editor extensions for AI agents
-- Framework-specific tools (LangChain, CrewAI, etc.)
-- CLI tools for skill management
-
----
+- **[tinybirdco/tinybird-best-practices](https://officialskills.sh/tinybirdco/skills/tinybird-best-practices)** - Tinybird project guidelines for datasources, pipes, endpoints, and SQL
+- **[tinybirdco/tinybird-cli-guidelines](https://officialskills.sh/tinybirdco/skills/tinybird-cli-guidelines)** - Tinybird CLI usage guidelines and commands
+- **[tinybirdco/tinybird-python-sdk-guidelines](https://officialskills.sh/tinybirdco/skills/tinybird-python-sdk-guidelines)** - Tinybird Python SDK usage guidelines
+- **[tinybirdco/tinybird-typescript-sdk-guidelines](https://officialskills.sh/tinybirdco/skills/tinybird-typescript-sdk-guidelines)** - Tinybird TypeScript SDK usage guidelines
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Skills by HashiCorp Team for Terraform</h3></summary>
+
+- **[hashicorp/azure-verified-modules](https://officialskills.sh/hashicorp/skills/azure-verified-modules)** - Azure Verified Modules (AVM) certification standards for Terraform modules
+- **[hashicorp/new-terraform-provider](https://officialskills.sh/hashicorp/skills/new-terraform-provider)** - Scaffold a new Terraform provider project using the Plugin Framework
+- **[hashicorp/provider-resources](https://officialskills.sh/hashicorp/skills/provider-resources)** - Implement Terraform Provider resources and data sources using the Plugin Framework
+- **[hashicorp/provider-test-patterns](https://officialskills.sh/hashicorp/skills/provider-test-patterns)** - Acceptance test patterns for Terraform providers using terraform-plugin-testing
+- **[hashicorp/provider-actions](https://officialskills.sh/hashicorp/skills/provider-actions)** - Implement Terraform Provider Actions using the Plugin Framework
+- **[hashicorp/run-acceptance-tests](https://officialskills.sh/hashicorp/skills/run-acceptance-tests)** - Run acceptance tests for Terraform providers using Go's test runner
+- **[hashicorp/refactor-module](https://officialskills.sh/hashicorp/skills/refactor-module)** - Transform monolithic Terraform configurations into reusable modules
+- **[hashicorp/terraform-search-import](https://officialskills.sh/hashicorp/skills/terraform-search-import)** - Discover existing cloud resources and bulk import them into Terraform state
+- **[hashicorp/terraform-style-guide](https://officialskills.sh/hashicorp/skills/terraform-style-guide)** - Generate Terraform HCL code following HashiCorp's official style conventions
+- **[hashicorp/terraform-stacks](https://officialskills.sh/hashicorp/skills/terraform-stacks)** - Manage infrastructure across multiple environments, regions, and cloud accounts
+- **[hashicorp/terraform-test](https://officialskills.sh/hashicorp/skills/terraform-test)** - Built-in testing framework for Terraform configurations with .tftest.hcl files
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Skills by Sanity Team</h3></summary>
+
+- **[sanity-io/sanity-best-practices](https://officialskills.sh/sanity-io/skills/sanity-best-practices)** - Best practices for Sanity Studio, GROQ queries, and content workflows
+- **[sanity-io/content-modeling-best-practices](https://officialskills.sh/sanity-io/skills/content-modeling-best-practices)** - Guidelines for designing scalable content models in Sanity
+- **[sanity-io/seo-aeo-best-practices](https://officialskills.sh/sanity-io/skills/seo-aeo-best-practices)** - SEO and answer engine optimization patterns for content sites
+- **[sanity-io/content-experimentation-best-practices](https://officialskills.sh/sanity-io/skills/content-experimentation-best-practices)** - Content A/B testing and experimentation workflows
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Skills by Firecrawl Team</h3></summary>
+
+- **[firecrawl/firecrawl-build](https://officialskills.sh/firecrawl/skills/firecrawl-build)** - Integrate Firecrawl into application code for web search, scraping, extraction, and browser interaction
+- **[firecrawl/firecrawl-build-interact](https://officialskills.sh/firecrawl/skills/firecrawl-build-interact)** - Multi-step Firecrawl browser flows: clicks, form fills, pagination, and auth-aware navigation
+- **[firecrawl/firecrawl-build-onboarding](https://officialskills.sh/firecrawl/skills/firecrawl-build-onboarding)** - Set up Firecrawl credentials and SDK in a project for the first integration
+- **[firecrawl/firecrawl-build-scrape](https://officialskills.sh/firecrawl/skills/firecrawl-build-scrape)** - Integrate Firecrawl `/scrape` for single-page extraction from product code
+- **[firecrawl/firecrawl-build-search](https://officialskills.sh/firecrawl/skills/firecrawl-build-search)** - Integrate Firecrawl `/search` for query-first discovery with optional content hydration
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Skills by Neon</h3></summary>
+
+- **[neondatabase/neon-postgres](https://officialskills.sh/neondatabase/skills/neon-postgres)** - Best practices for Neon Serverless Postgres
+- **[neondatabase/claimable-postgres](https://officialskills.sh/neondatabase/skills/claimable-postgres)** - Claimable Postgres database provisioning with Neon
+- **[neondatabase/neon-postgres-egress-optimizer](https://officialskills.sh/neondatabase/skills/neon-postgres-egress-optimizer)** - Optimize Neon Postgres egress and data transfer
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Skills by ClickHouse</h3></summary>
+
+- **[clickhouse/clickhouse-best-practices](https://officialskills.sh/clickhouse/skills/clickhouse-best-practices)** - Best practices for working with ClickHouse
+- **[clickhouse/chdb-datastore](https://officialskills.sh/clickhouse/skills/chdb-datastore)** - Drop-in pandas replacement with ClickHouse performance across 16+ data sources
+- **[clickhouse/chdb-sql](https://officialskills.sh/clickhouse/skills/chdb-sql)** - In-process ClickHouse SQL engine for Python — query files, databases, and cloud storage without a server
+- **[clickhouse/clickhouse-architecture-advisor](https://officialskills.sh/clickhouse/skills/clickhouse-architecture-advisor)** - Design ClickHouse architectures and translate best practices into workload-specific decisions
+- **[clickhouse/clickhousectl-cloud-deploy](https://officialskills.sh/clickhouse/skills/clickhousectl-cloud-deploy)** - Deploy to ClickHouse Cloud and migrate from local setups with clickhousectl
+- **[clickhouse/clickhousectl-local-dev](https://officialskills.sh/clickhouse/skills/clickhousectl-local-dev)** - Spin up a local ClickHouse development environment from zero with clickhousectl
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Skills by Remotion</h3></summary>
+
+- **[remotion-dev/remotion](https://officialskills.sh/remotion-dev/skills/remotion)** - Programmatic video creation with React
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Skills by Replicate</h3></summary>
+
+- **[replicate/replicate](https://officialskills.sh/replicate/skills/replicate)** - Discover, compare, and run AI models using Replicate's API
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Skills by Typefully</h3></summary>
+
+- **[typefully/typefully](https://officialskills.sh/typefully/skills/typefully)** - Create, schedule, and publish social media content across X, LinkedIn, Threads, Bluesky, and Mastodon
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Skills by Venice.ai</h3></summary>
+
+Official skills by Venice.ai for the Venice API.
+
+- **[veniceai/venice-api-overview](https://github.com/veniceai/skills/tree/main/skills/venice-api-overview)** - API basics, auth modes, pricing, and versioning
+- **[veniceai/venice-auth](https://github.com/veniceai/skills/tree/main/skills/venice-auth)** - API keys and wallet-based Venice authentication
+- **[veniceai/venice-chat](https://github.com/veniceai/skills/tree/main/skills/venice-chat)** - Chat completions, multimodal inputs, tools, and streaming
+- **[veniceai/venice-responses](https://github.com/veniceai/skills/tree/main/skills/venice-responses)** - OpenAI-compatible Responses API for Venice
+- **[veniceai/venice-embeddings](https://github.com/veniceai/skills/tree/main/skills/venice-embeddings)** - Embeddings models, dimensions, and encoding formats
+- **[veniceai/venice-image-generate](https://github.com/veniceai/skills/tree/main/skills/venice-image-generate)** - Image generation endpoints and available styles
+- **[veniceai/venice-image-edit](https://github.com/veniceai/skills/tree/main/skills/venice-image-edit)** - Image edits, upscaling, and background removal
+- **[veniceai/venice-audio-speech](https://github.com/veniceai/skills/tree/main/skills/venice-audio-speech)** - Text-to-speech models, voices, formats, and streaming
+- **[veniceai/venice-audio-music](https://github.com/veniceai/skills/tree/main/skills/venice-audio-music)** - Music generation queueing, retrieval, and completion endpoints
+- **[veniceai/venice-audio-transcription](https://github.com/veniceai/skills/tree/main/skills/venice-audio-transcription)** - Audio transcription models and speech-to-text options
+- **[veniceai/venice-video](https://github.com/veniceai/skills/tree/main/skills/venice-video)** - Video generation and transcription workflows
+- **[veniceai/venice-models](https://github.com/veniceai/skills/tree/main/skills/venice-models)** - Model catalog, traits, and compatibility mappings
+- **[veniceai/venice-characters](https://github.com/veniceai/skills/tree/main/skills/venice-characters)** - Character endpoints and `character_slug` usage
+- **[veniceai/venice-api-keys](https://github.com/veniceai/skills/tree/main/skills/venice-api-keys)** - API key CRUD, rate limits, and Web3 keys
+- **[veniceai/venice-billing](https://github.com/veniceai/skills/tree/main/skills/venice-billing)** - Balance, usage, and billing analytics endpoints
+- **[veniceai/venice-x402](https://github.com/veniceai/skills/tree/main/skills/venice-x402)** - Wallet credits and x402 payments on Base
+- **[veniceai/venice-crypto-rpc](https://github.com/veniceai/skills/tree/main/skills/venice-crypto-rpc)** - JSON-RPC proxying for supported crypto networks
+- **[veniceai/venice-augment](https://github.com/veniceai/skills/tree/main/skills/venice-augment)** - Search, scraping, and text parsing endpoints
+- **[veniceai/venice-errors](https://github.com/veniceai/skills/tree/main/skills/venice-errors)** - Error handling, retries, and API status codes
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Skills by Vercel Engineering Team</h3></summary>
+
+- **[vercel-labs/next-best-practices](https://officialskills.sh/vercel-labs/skills/next-best-practices)** - Next.js best practices and recommended patterns
+- **[vercel-labs/next-cache-components](https://officialskills.sh/vercel-labs/skills/next-cache-components)** - Caching strategies and cache-aware components in Next.js
+- **[vercel-labs/next-upgrade](https://officialskills.sh/vercel-labs/skills/next-upgrade)** - Upgrade Next.js projects to newer versions
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Skills by Cloudflare Team</h3></summary>
+
+- **[cloudflare/agents-sdk](https://officialskills.sh/cloudflare/skills/agents-sdk)** - Build stateful AI agents with scheduling, RPC, and MCP servers
+- **[cloudflare/cloudflare](https://officialskills.sh/cloudflare/skills/cloudflare)** - Comprehensive Cloudflare platform skill covering Workers, Pages, storage, AI, networking, security, and IaC
+- **[cloudflare/cloudflare-email-service](https://officialskills.sh/cloudflare/skills/cloudflare-email-service)** - Send transactional email and route inbound mail with Cloudflare Email Sending and Email Routing
+- **[cloudflare/durable-objects](https://officialskills.sh/cloudflare/skills/durable-objects)** - Stateful coordination with RPC, SQLite, and WebSockets
+- **[cloudflare/sandbox-sdk](https://officialskills.sh/cloudflare/skills/sandbox-sdk)** - Build sandboxed applications for secure, isolated code execution on Workers
+- **[cloudflare/web-perf](https://officialskills.sh/cloudflare/skills/web-perf)** - Audit Core Web Vitals and render-blocking resources
+- **[cloudflare/workers-best-practices](https://officialskills.sh/cloudflare/skills/workers-best-practices)** - Review and author Workers code against production best practices and wrangler.jsonc conventions
+- **[cloudflare/wrangler](https://officialskills.sh/cloudflare/skills/wrangler)** - Deploy and manage Workers, KV, R2, D1, Vectorize, Queues, Workflows
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Skills by Netlify Team</h3></summary>
+
+- **[netlify/netlify-functions](https://officialskills.sh/netlify/skills/netlify-functions)** - Build serverless API endpoints and background tasks
+- **[netlify/netlify-edge-functions](https://officialskills.sh/netlify/skills/netlify-edge-functions)** - Low-latency edge middleware and geolocation logic
+- **[netlify/netlify-blobs](https://officialskills.sh/netlify/skills/netlify-blobs)** - Key-value object storage for files and data
+- **[netlify/netlify-db](https://officialskills.sh/netlify/skills/netlify-db)** - Managed Postgres with deploy preview branching
+- **[netlify/netlify-image-cdn](https://officialskills.sh/netlify/skills/netlify-image-cdn)** - Optimize and transform images via CDN
+- **[netlify/netlify-forms](https://officialskills.sh/netlify/skills/netlify-forms)** - HTML form handling with spam filtering
+- **[netlify/netlify-frameworks](https://officialskills.sh/netlify/skills/netlify-frameworks)** - Deploy web frameworks with SSR support
+- **[netlify/netlify-caching](https://officialskills.sh/netlify/skills/netlify-caching)** - Configure CDN caching and cache purging
+- **[netlify/netlify-config](https://officialskills.sh/netlify/skills/netlify-config)** - Reference for netlify.toml site configuration
+- **[netlify/netlify-cli-and-deploy](https://officialskills.sh/netlify/skills/netlify-cli-and-deploy)** - CLI setup, local dev, and deployment workflows
+- **[netlify/netlify-deploy](https://officialskills.sh/netlify/skills/netlify-deploy)** - Automated deployment workflow for Netlify sites
+- **[netlify/netlify-ai-gateway](https://officialskills.sh/netlify/skills/netlify-ai-gateway)** - Access AI models via unified gateway endpoint
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Skills by Google Labs (Stitch)</h3></summary>
+
+Agent Skills for the Stitch MCP server, compatible with Claude Code, Gemini CLI, Cursor, and more.
+
+- **[google-labs-code/design-md](https://officialskills.sh/google-labs-code/skills/design-md)** - Create and manage DESIGN.md files
+- **[google-labs-code/enhance-prompt](https://officialskills.sh/google-labs-code/skills/enhance-prompt)** - Improve prompts with design specs and UI/UX vocabulary
+- **[google-labs-code/react-components](https://officialskills.sh/google-labs-code/skills/react-components)** - Stitch to React components conversion
+- **[google-labs-code/remotion](https://officialskills.sh/google-labs-code/skills/remotion)** - Generate walkthrough videos from Stitch app designs
+- **[google-labs-code/shadcn-ui](https://officialskills.sh/google-labs-code/skills/shadcn-ui)** - Build UI components with shadcn/ui
+- **[google-labs-code/stitch-loop](https://officialskills.sh/google-labs-code/skills/stitch-loop)** - Iterative design-to-code feedback loop
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Skills by Google Workspace CLI</h3></summary>
+
+Official Google Workspace CLI skills for managing Google Workspace services via the `gws` CLI tool.
+
+- **[googleworkspace/gws-shared](https://officialskills.sh/googleworkspace/skills/gws-shared)** - Shared authentication, global flags, and output formatting
+- **[googleworkspace/gws-drive](https://officialskills.sh/googleworkspace/skills/gws-drive)** - Manage Google Drive files, folders, and shared drives
+- **[googleworkspace/gws-sheets](https://officialskills.sh/googleworkspace/skills/gws-sheets)** - Read and write Google Sheets spreadsheets
+- **[googleworkspace/gws-gmail](https://officialskills.sh/googleworkspace/skills/gws-gmail)** - Send, read, and manage Gmail email
+- **[googleworkspace/gws-calendar](https://officialskills.sh/googleworkspace/skills/gws-calendar)** - Manage Google Calendar calendars and events
+- **[googleworkspace/gws-admin-reports](https://officialskills.sh/googleworkspace/skills/gws-admin-reports)** - Audit logs and usage reports for Workspace
+- **[googleworkspace/gws-docs](https://officialskills.sh/googleworkspace/skills/gws-docs)** - Read and write Google Docs documents
+- **[googleworkspace/gws-slides](https://officialskills.sh/googleworkspace/skills/gws-slides)** - Read and write Google Slides presentations
+- **[googleworkspace/gws-tasks](https://officialskills.sh/googleworkspace/skills/gws-tasks)** - Manage Google Tasks task lists and tasks
+- **[googleworkspace/gws-people](https://officialskills.sh/googleworkspace/skills/gws-people)** - Manage Google People contacts and profiles
+- **[googleworkspace/gws-chat](https://officialskills.sh/googleworkspace/skills/gws-chat)** - Manage Google Chat spaces and messages
+- **[googleworkspace/gws-classroom](https://officialskills.sh/googleworkspace/skills/gws-classroom)** - Manage Google Classroom classes, rosters, and coursework
+- **[googleworkspace/gws-forms](https://officialskills.sh/googleworkspace/skills/gws-forms)** - Read and write Google Forms
+- **[googleworkspace/gws-keep](https://officialskills.sh/googleworkspace/skills/gws-keep)** - Manage Google Keep notes
+- **[googleworkspace/gws-events](https://officialskills.sh/googleworkspace/skills/gws-events)** - Subscribe to Google Workspace events
+- **[googleworkspace/gws-modelarmor](https://officialskills.sh/googleworkspace/skills/gws-modelarmor)** - Filter user-generated content for safety
+- **[googleworkspace/gws-workflow](https://officialskills.sh/googleworkspace/skills/gws-workflow)** - Cross-service Google Workspace productivity workflows
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Skills by Expo Team</h3></summary>
+
+Official AI agent skills from the Expo team for building, deploying, and debugging Expo apps.
+
+- **[expo/building-native-ui](https://officialskills.sh/expo/skills/building-native-ui)** - Build apps with Expo Router, styling, components, navigation, and animations
+- **[expo/expo-api-routes](https://officialskills.sh/expo/skills/expo-api-routes)** - Create API routes in Expo Router with EAS Hosting
+- **[expo/expo-cicd-workflows](https://officialskills.sh/expo/skills/expo-cicd-workflows)** - CI/CD workflows for Expo projects
+- **[expo/expo-deployment](https://officialskills.sh/expo/skills/expo-deployment)** - Deploy Expo apps to production
+- **[expo/expo-dev-client](https://officialskills.sh/expo/skills/expo-dev-client)** - Build and distribute Expo dev clients locally or via TestFlight
+- **[expo/expo-tailwind-setup](https://officialskills.sh/expo/skills/expo-tailwind-setup)** - Set up Tailwind CSS v4 in Expo with NativeWind v5
+- **[expo/expo-ui-jetpack-compose](https://officialskills.sh/expo/skills/expo-ui-jetpack-compose)** - Jetpack Compose UI components for Expo
+- **[expo/expo-ui-swift-ui](https://officialskills.sh/expo/skills/expo-ui-swift-ui)** - SwiftUI components for Expo
+- **[expo/native-data-fetching](https://officialskills.sh/expo/skills/native-data-fetching)** - Network requests, API calls, caching, and offline support
+- **[expo/upgrading-expo](https://officialskills.sh/expo/skills/upgrading-expo)** - Upgrade Expo SDK versions
+- **[expo/use-dom](https://officialskills.sh/expo/skills/use-dom)** - Run web code in a webview on native using DOM components
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Skills by Hugging Face Team</h3></summary>
+
+Official AI agent skills from the Hugging Face team for ML workflows.
+
+- **[huggingface/hf-cli](https://officialskills.sh/huggingface/skills/hf-cli)** - HF CLI tool for Hub operations
+- **[huggingface/hugging-face-dataset-viewer](https://officialskills.sh/huggingface/skills/hugging-face-dataset-viewer)** - Browse and query HF datasets with the Dataset Viewer API
+- **[huggingface/hugging-face-datasets](https://officialskills.sh/huggingface/skills/hugging-face-datasets)** - Create and manage datasets with configs and SQL querying
+- **[huggingface/hugging-face-evaluation](https://officialskills.sh/huggingface/skills/hugging-face-evaluation)** - Model evaluation with vLLM/lighteval and eval tables
+- **[huggingface/hugging-face-jobs](https://officialskills.sh/huggingface/skills/hugging-face-jobs)** - Run compute jobs and Python scripts on HF infrastructure
+- **[huggingface/hugging-face-model-trainer](https://officialskills.sh/huggingface/skills/hugging-face-model-trainer)** - Train models with TRL: SFT, DPO, GRPO, GGUF conversion
+- **[huggingface/hugging-face-paper-pages](https://officialskills.sh/huggingface/skills/hugging-face-paper-pages)** - Create and manage paper pages on HF Hub
+- **[huggingface/hugging-face-paper-publisher](https://officialskills.sh/huggingface/skills/hugging-face-paper-publisher)** - Publish papers on HF Hub with model/dataset links
+- **[huggingface/hugging-face-tool-builder](https://officialskills.sh/huggingface/skills/hugging-face-tool-builder)** - Build reusable scripts for HF API operations
+- **[huggingface/hugging-face-trackio](https://officialskills.sh/huggingface/skills/hugging-face-trackio)** - Track ML experiments with real-time dashboards
+- **[huggingface/hugging-face-vision-trainer](https://officialskills.sh/huggingface/skills/hugging-face-vision-trainer)** - Train vision models on HF infrastructure
+- **[huggingface/huggingface-gradio](https://officialskills.sh/huggingface/skills/huggingface-gradio)** - Build Gradio apps and deploy to HF Spaces
+- **[huggingface/transformers.js](https://officialskills.sh/huggingface/skills/transformers.js)** - Run ML models in the browser with Transformers.js
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Security Skills by Trail of Bits Team</h3></summary>
+
+- **[trailofbits/ask-questions-if-underspecified](https://officialskills.sh/trailofbits/skills/ask-questions-if-underspecified)** - Prompt for clarification on ambiguous requirements
+- **[trailofbits/audit-context-building](https://officialskills.sh/trailofbits/skills/audit-context-building)** - Deep architectural context via ultra-granular code analysis
+- **[trailofbits/building-secure-contracts](https://officialskills.sh/trailofbits/skills/building-secure-contracts)** - Smart contract security toolkit with vulnerability scanners for 6 blockchains
+- **[trailofbits/burpsuite-project-parser](https://officialskills.sh/trailofbits/skills/burpsuite-project-parser)** - Search and extract data from Burp Suite project files
+- **[trailofbits/claude-in-chrome-troubleshooting](https://officialskills.sh/trailofbits/skills/claude-in-chrome-troubleshooting)** - Diagnose and fix Claude in Chrome MCP extension connectivity issues
+- **[trailofbits/constant-time-analysis](https://officialskills.sh/trailofbits/skills/constant-time-analysis)** - Detect compiler-induced timing side-channels in crypto code
+- **[trailofbits/culture-index](https://officialskills.sh/trailofbits/skills/culture-index)** - Index and search culture documentation
+- **[trailofbits/differential-review](https://officialskills.sh/trailofbits/skills/differential-review)** - Security-focused diff review with git history analysis
+- **[trailofbits/dwarf-expert](https://officialskills.sh/trailofbits/skills/dwarf-expert)** - DWARF debugging format expertise
+- **[trailofbits/entry-point-analyzer](https://officialskills.sh/trailofbits/skills/entry-point-analyzer)** - Identify state-changing entry points in smart contracts
+- **[trailofbits/firebase-apk-scanner](https://officialskills.sh/trailofbits/skills/firebase-apk-scanner)** - Scan Android APKs for Firebase misconfigurations and security vulnerabilities
+- **[trailofbits/insecure-defaults](https://officialskills.sh/trailofbits/skills/insecure-defaults)** - Detect insecure default configurations like hardcoded secrets, default credentials, and weak crypto
+- **[trailofbits/modern-python](https://officialskills.sh/trailofbits/skills/modern-python)** - Modern Python tooling with uv, ruff, ty, and pytest best practices
+- **[trailofbits/property-based-testing](https://officialskills.sh/trailofbits/skills/property-based-testing)** - Property-based testing for multiple languages and smart contracts
+- **[trailofbits/semgrep-rule-creator](https://officialskills.sh/trailofbits/skills/semgrep-rule-creator)** - Create and refine Semgrep rules for vulnerability detection
+- **[trailofbits/semgrep-rule-variant-creator](https://officialskills.sh/trailofbits/skills/semgrep-rule-variant-creator)** - Port existing Semgrep rules to new target languages with test-driven validation
+- **[trailofbits/sharp-edges](https://officialskills.sh/trailofbits/skills/sharp-edges)** - Identify error-prone APIs and dangerous configurations
+- **[trailofbits/spec-to-code-compliance](https://officialskills.sh/trailofbits/skills/spec-to-code-compliance)** - Specification-to-code compliance checker for blockchain audits
+- **[trailofbits/static-analysis](https://officialskills.sh/trailofbits/skills/static-analysis)** - Static analysis toolkit with CodeQL, Semgrep, and SARIF
+- **[trailofbits/testing-handbook-skills](https://officialskills.sh/trailofbits/skills/testing-handbook-skills)** - Testing Handbook skills: fuzzers, static analysis, sanitizers
+- **[trailofbits/variant-analysis](https://officialskills.sh/trailofbits/skills/variant-analysis)** - Find similar vulnerabilities via pattern-based analysis
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Skills by Sentry team for their dev team.</h3></summary>
+
+- **[getsentry/sentry-sdk-setup](https://officialskills.sh/getsentry/skills/sentry-sdk-setup)** - Set up Sentry in any language or framework — detects platform and routes to the right SDK
+- **[getsentry/sentry-workflow](https://officialskills.sh/getsentry/skills/sentry-workflow)** - End-to-end Sentry workflow: fix production issues and review code with Sentry context
+- **[getsentry/sentry-fix-issues](https://officialskills.sh/getsentry/skills/sentry-fix-issues)** - Find and fix Sentry issues with stack trace, breadcrumb, and trace context via MCP
+- **[getsentry/sentry-code-review](https://officialskills.sh/getsentry/skills/sentry-code-review)** - Review code changes using Sentry issue and trace context
+- **[getsentry/sentry-pr-code-review](https://officialskills.sh/getsentry/skills/sentry-pr-code-review)** - Review PR comments from Seer Bug Prediction and Sentry feedback
+- **[getsentry/sentry-create-alert](https://officialskills.sh/getsentry/skills/sentry-create-alert)** - Create Sentry alerts with email, Slack, PagerDuty, Discord, and more
+- **[getsentry/sentry-feature-setup](https://officialskills.sh/getsentry/skills/sentry-feature-setup)** - Configure advanced Sentry features: AI monitoring, OTel pipelines, and alerts
+- **[getsentry/sentry-otel-exporter-setup](https://officialskills.sh/getsentry/skills/sentry-otel-exporter-setup)** - Configure the OpenTelemetry Collector with Sentry Exporter
+- **[getsentry/sentry-setup-ai-monitoring](https://officialskills.sh/getsentry/skills/sentry-setup-ai-monitoring)** - Instrument OpenAI, Anthropic, Vercel AI, LangChain, Google GenAI, and Pydantic AI
+- **[getsentry/sentry-sdk-upgrade](https://officialskills.sh/getsentry/skills/sentry-sdk-upgrade)** - Upgrade the Sentry JavaScript SDK across major versions
+- **[getsentry/sentry-sdk-skill-creator](https://officialskills.sh/getsentry/skills/sentry-sdk-skill-creator)** - Create a new Sentry SDK skill bundle for a platform
+- **[getsentry/sentry-android-sdk](https://officialskills.sh/getsentry/skills/sentry-android-sdk)** - Full Sentry SDK setup for Android (Kotlin and Java)
+- **[getsentry/sentry-browser-sdk](https://officialskills.sh/getsentry/skills/sentry-browser-sdk)** - Full Sentry SDK setup for browser JavaScript
+- **[getsentry/sentry-cloudflare-sdk](https://officialskills.sh/getsentry/skills/sentry-cloudflare-sdk)** - Full Sentry SDK setup for Cloudflare Workers, Pages, Durable Objects, Queues, and Workflows
+- **[getsentry/sentry-cocoa-sdk](https://officialskills.sh/getsentry/skills/sentry-cocoa-sdk)** - Full Sentry SDK setup for Apple platforms (iOS, macOS, tvOS, watchOS, visionOS)
+- **[getsentry/sentry-dotnet-sdk](https://officialskills.sh/getsentry/skills/sentry-dotnet-sdk)** - Full Sentry SDK setup for .NET (ASP.NET Core, MAUI, WPF, WinForms, Blazor, Azure Functions)
+- **[getsentry/sentry-elixir-sdk](https://officialskills.sh/getsentry/skills/sentry-elixir-sdk)** - Full Sentry SDK setup for Elixir, Phoenix, Plug, LiveView, Oban, and Quantum
+- **[getsentry/sentry-flutter-sdk](https://officialskills.sh/getsentry/skills/sentry-flutter-sdk)** - Full Sentry SDK setup for Flutter and Dart across all platforms
+- **[getsentry/sentry-go-sdk](https://officialskills.sh/getsentry/skills/sentry-go-sdk)** - Full Sentry SDK setup for Go (net/http, Gin, Echo, Fiber, FastHTTP, Iris, Negroni)
+- **[getsentry/sentry-nestjs-sdk](https://officialskills.sh/getsentry/skills/sentry-nestjs-sdk)** - Full Sentry SDK setup for NestJS with Express or Fastify, GraphQL, microservices
+- **[getsentry/sentry-nextjs-sdk](https://officialskills.sh/getsentry/skills/sentry-nextjs-sdk)** - Full Sentry SDK setup for Next.js 13+ (App Router and Pages Router)
+- **[getsentry/sentry-node-sdk](https://officialskills.sh/getsentry/skills/sentry-node-sdk)** - Full Sentry SDK setup for Node.js, Bun, and Deno
+- **[getsentry/sentry-php-sdk](https://officialskills.sh/getsentry/skills/sentry-php-sdk)** - Full Sentry SDK setup for PHP, Laravel, and Symfony
+- **[getsentry/sentry-python-sdk](https://officialskills.sh/getsentry/skills/sentry-python-sdk)** - Full Sentry SDK setup for Python (Django, Flask, FastAPI, Celery, Starlette, AIOHTTP, Tornado)
+- **[getsentry/sentry-react-native-sdk](https://officialskills.sh/getsentry/skills/sentry-react-native-sdk)** - Full Sentry SDK setup for React Native and Expo
+- **[getsentry/sentry-react-sdk](https://officialskills.sh/getsentry/skills/sentry-react-sdk)** - Full Sentry SDK setup for React (React Router v5-v7, TanStack Router, Redux, Vite, webpack)
+- **[getsentry/sentry-ruby-sdk](https://officialskills.sh/getsentry/skills/sentry-ruby-sdk)** - Full Sentry SDK setup for Ruby (Rails, Sinatra, Rack, Sidekiq, Resque)
+- **[getsentry/sentry-svelte-sdk](https://officialskills.sh/getsentry/skills/sentry-svelte-sdk)** - Full Sentry SDK setup for Svelte and SvelteKit
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Skills by Microsoft</h3></summary>
+
+Domain-specific knowledge for Azure SDK and Microsoft AI Foundry development. 133 skills across 6 languages.
+
+### Core Skills
+
+- **[microsoft/cloud-solution-architect](https://officialskills.sh/microsoft/skills/cloud-solution-architect)** - Design well-architected Azure cloud systems
+- **[microsoft/continual-learning](https://officialskills.sh/microsoft/skills/continual-learning)** - Continual learning patterns for Azure AI
+- **[microsoft/copilot-sdk](https://officialskills.sh/microsoft/skills/copilot-sdk)** - Build applications powered by GitHub Copilot SDK
+- **[microsoft/entra-agent-id](https://officialskills.sh/microsoft/skills/entra-agent-id)** - Microsoft Entra Agent ID OAuth2 identities via Graph API
+- **[microsoft/frontend-design-review](https://officialskills.sh/microsoft/skills/frontend-design-review)** - Review and create distinctive frontend interfaces
+- **[microsoft/github-issue-creator](https://officialskills.sh/microsoft/skills/github-issue-creator)** - Structured GitHub issue reports from notes
+- **[microsoft/mcp-builder](https://officialskills.sh/microsoft/skills/mcp-builder)** - MCP server creation guide for LLM tool integration
+- **[microsoft/podcast-generation](https://officialskills.sh/microsoft/skills/podcast-generation)** - AI podcast audio with Azure OpenAI Realtime API
+- **[microsoft/skill-creator](https://officialskills.sh/microsoft/skills/skill-creator)** - Guide for creating effective skills for AI coding agents
+
+### .NET Skills
+
+- **[microsoft/azure-ai-document-intelligence-dotnet](https://officialskills.sh/microsoft/skills/azure-ai-document-intelligence-dotnet)** - Document text, table, and data extraction
+- **[microsoft/azure-ai-openai-dotnet](https://officialskills.sh/microsoft/skills/azure-ai-openai-dotnet)** - GPT-4, embeddings, DALL-E, and Whisper client
+- **[microsoft/azure-ai-projects-dotnet](https://officialskills.sh/microsoft/skills/azure-ai-projects-dotnet)** - AI Foundry project management SDK
+- **[microsoft/azure-ai-voicelive-dotnet](https://officialskills.sh/microsoft/skills/azure-ai-voicelive-dotnet)** - Real-time bidirectional voice AI
+- **[microsoft/azure-eventgrid-dotnet](https://officialskills.sh/microsoft/skills/azure-eventgrid-dotnet)** - Event Grid topic and domain publishing
+- **[microsoft/azure-eventhub-dotnet](https://officialskills.sh/microsoft/skills/azure-eventhub-dotnet)** - High-throughput event streaming
+- **[microsoft/azure-identity-dotnet](https://officialskills.sh/microsoft/skills/azure-identity-dotnet)** - Microsoft Entra ID authentication
+- **[microsoft/azure-maps-search-dotnet](https://officialskills.sh/microsoft/skills/azure-maps-search-dotnet)** - Geocoding, routing, and weather services
+- **[microsoft/azure-mgmt-apicenter-dotnet](https://officialskills.sh/microsoft/skills/azure-mgmt-apicenter-dotnet)** - API inventory and governance
+- **[microsoft/azure-mgmt-apimanagement-dotnet](https://officialskills.sh/microsoft/skills/azure-mgmt-apimanagement-dotnet)** - API Management provisioning via ARM
+- **[microsoft/azure-mgmt-applicationinsights-dotnet](https://officialskills.sh/microsoft/skills/azure-mgmt-applicationinsights-dotnet)** - Application Insights resource management
+- **[microsoft/azure-mgmt-arizeaiobservabilityeval-dotnet](https://officialskills.sh/microsoft/skills/azure-mgmt-arizeaiobservabilityeval-dotnet)** - Arize AI observability management
+- **[microsoft/azure-mgmt-botservice-dotnet](https://officialskills.sh/microsoft/skills/azure-mgmt-botservice-dotnet)** - Bot Service provisioning via ARM
+- **[microsoft/azure-mgmt-fabric-dotnet](https://officialskills.sh/microsoft/skills/azure-mgmt-fabric-dotnet)** - Microsoft Fabric capacity management
+- **[microsoft/azure-mgmt-mongodbatlas-dotnet](https://officialskills.sh/microsoft/skills/azure-mgmt-mongodbatlas-dotnet)** - MongoDB Atlas as ARM resources
+- **[microsoft/azure-mgmt-weightsandbiases-dotnet](https://officialskills.sh/microsoft/skills/azure-mgmt-weightsandbiases-dotnet)** - Weights & Biases deployment management
+- **[microsoft/azure-resource-manager-cosmosdb-dotnet](https://officialskills.sh/microsoft/skills/azure-resource-manager-cosmosdb-dotnet)** - Cosmos DB resource provisioning
+- **[microsoft/azure-resource-manager-durabletask-dotnet](https://officialskills.sh/microsoft/skills/azure-resource-manager-durabletask-dotnet)** - Durable Task Scheduler management
+- **[microsoft/azure-resource-manager-mysql-dotnet](https://officialskills.sh/microsoft/skills/azure-resource-manager-mysql-dotnet)** - MySQL Flexible Server management
+- **[microsoft/azure-resource-manager-playwright-dotnet](https://officialskills.sh/microsoft/skills/azure-resource-manager-playwright-dotnet)** - Playwright Testing workspace management
+- **[microsoft/azure-resource-manager-postgresql-dotnet](https://officialskills.sh/microsoft/skills/azure-resource-manager-postgresql-dotnet)** - PostgreSQL Flexible Server management
+- **[microsoft/azure-resource-manager-redis-dotnet](https://officialskills.sh/microsoft/skills/azure-resource-manager-redis-dotnet)** - Azure Cache for Redis provisioning
+- **[microsoft/azure-resource-manager-sql-dotnet](https://officialskills.sh/microsoft/skills/azure-resource-manager-sql-dotnet)** - Azure SQL resource management
+- **[microsoft/azure-search-documents-dotnet](https://officialskills.sh/microsoft/skills/azure-search-documents-dotnet)** - Full-text, vector, and hybrid search
+- **[microsoft/azure-security-keyvault-keys-dotnet](https://officialskills.sh/microsoft/skills/azure-security-keyvault-keys-dotnet)** - Cryptographic key management
+- **[microsoft/azure-servicebus-dotnet](https://officialskills.sh/microsoft/skills/azure-servicebus-dotnet)** - Enterprise messaging with queues and topics
+- **[microsoft/m365-agents-dotnet](https://officialskills.sh/microsoft/skills/m365-agents-dotnet)** - M365, Teams, and Copilot Studio agents
+- **[microsoft/microsoft-azure-webjobs-extensions-authentication-events-dotnet](https://officialskills.sh/microsoft/skills/microsoft-azure-webjobs-extensions-authentication-events-dotnet)** - Entra ID custom auth events handler
+
+### Java Skills
+
+- **[microsoft/azure-ai-anomalydetector-java](https://officialskills.sh/microsoft/skills/azure-ai-anomalydetector-java)** - Anomaly detection applications
+- **[microsoft/azure-ai-contentsafety-java](https://officialskills.sh/microsoft/skills/azure-ai-contentsafety-java)** - Content moderation and safety
+- **[microsoft/azure-ai-formrecognizer-java](https://officialskills.sh/microsoft/skills/azure-ai-formrecognizer-java)** - Document analysis and form extraction
+- **[microsoft/azure-ai-projects-java](https://officialskills.sh/microsoft/skills/azure-ai-projects-java)** - AI Foundry project management
+- **[microsoft/azure-ai-vision-imageanalysis-java](https://officialskills.sh/microsoft/skills/azure-ai-vision-imageanalysis-java)** - Image captioning, OCR, and object detection
+- **[microsoft/azure-ai-voicelive-java](https://officialskills.sh/microsoft/skills/azure-ai-voicelive-java)** - Real-time bidirectional voice AI
+- **[microsoft/azure-appconfiguration-java](https://officialskills.sh/microsoft/skills/azure-appconfiguration-java)** - Centralized app configuration management
+- **[microsoft/azure-communication-callautomation-java](https://officialskills.sh/microsoft/skills/azure-communication-callautomation-java)** - Call automation with IVR and AI
+- **[microsoft/azure-communication-callingserver-java](https://officialskills.sh/microsoft/skills/azure-communication-callingserver-java)** - CallingServer legacy SDK
+- **[microsoft/azure-communication-chat-java](https://officialskills.sh/microsoft/skills/azure-communication-chat-java)** - Real-time chat with threads and receipts
+- **[microsoft/azure-communication-common-java](https://officialskills.sh/microsoft/skills/azure-communication-common-java)** - Communication Services common utilities
+- **[microsoft/azure-communication-sms-java](https://officialskills.sh/microsoft/skills/azure-communication-sms-java)** - SMS sending and delivery reports
+- **[microsoft/azure-compute-batch-java](https://officialskills.sh/microsoft/skills/azure-compute-batch-java)** - Large-scale parallel and HPC batch jobs
+- **[microsoft/azure-cosmos-java](https://officialskills.sh/microsoft/skills/azure-cosmos-java)** - Cosmos DB NoSQL with global distribution
+- **[microsoft/azure-data-tables-java](https://officialskills.sh/microsoft/skills/azure-data-tables-java)** - NoSQL key-value table storage
+- **[microsoft/azure-eventgrid-java](https://officialskills.sh/microsoft/skills/azure-eventgrid-java)** - Event-driven pub/sub messaging
+- **[microsoft/azure-eventhub-java](https://officialskills.sh/microsoft/skills/azure-eventhub-java)** - Real-time high-throughput streaming
+- **[microsoft/azure-identity-java](https://officialskills.sh/microsoft/skills/azure-identity-java)** - Microsoft Entra ID authentication
+- **[microsoft/azure-messaging-webpubsub-java](https://officialskills.sh/microsoft/skills/azure-messaging-webpubsub-java)** - Real-time WebSocket messaging
+- **[microsoft/azure-monitor-ingestion-java](https://officialskills.sh/microsoft/skills/azure-monitor-ingestion-java)** - Custom log ingestion to Azure Monitor
+- **[microsoft/azure-monitor-opentelemetry-exporter-java](https://officialskills.sh/microsoft/skills/azure-monitor-opentelemetry-exporter-java)** - OpenTelemetry export to Azure Monitor
+- **[microsoft/azure-monitor-query-java](https://officialskills.sh/microsoft/skills/azure-monitor-query-java)** - Query Azure Monitor logs and metrics
+- **[microsoft/azure-security-keyvault-keys-java](https://officialskills.sh/microsoft/skills/azure-security-keyvault-keys-java)** - Cryptographic key management
+- **[microsoft/azure-security-keyvault-secrets-java](https://officialskills.sh/microsoft/skills/azure-security-keyvault-secrets-java)** - Secret management for passwords and keys
+- **[microsoft/azure-storage-blob-java](https://officialskills.sh/microsoft/skills/azure-storage-blob-java)** - Blob storage for file management
+
+### Python Skills
+
+- **[microsoft/agent-framework-azure-ai-py](https://officialskills.sh/microsoft/skills/agent-framework-azure-ai-py)** - Agent Framework for Azure AI Foundry
+- **[microsoft/agents-v2-py](https://officialskills.sh/microsoft/skills/agents-v2-py)** - Foundry Agents SDK — container-based agents with custom images
+- **[microsoft/azure-ai-contentsafety-py](https://officialskills.sh/microsoft/skills/azure-ai-contentsafety-py)** - Harmful content detection
+- **[microsoft/azure-ai-contentunderstanding-py](https://officialskills.sh/microsoft/skills/azure-ai-contentunderstanding-py)** - Multimodal content extraction
+- **[microsoft/azure-ai-ml-py](https://officialskills.sh/microsoft/skills/azure-ai-ml-py)** - Azure ML workspace and job management
+- **[microsoft/azure-ai-projects-py](https://officialskills.sh/microsoft/skills/azure-ai-projects-py)** - AI Foundry project client and agents
+- **[microsoft/azure-ai-textanalytics-py](https://officialskills.sh/microsoft/skills/azure-ai-textanalytics-py)** - NLP: sentiment, entities, key phrases
+- **[microsoft/azure-ai-transcription-py](https://officialskills.sh/microsoft/skills/azure-ai-transcription-py)** - Speech-to-text transcription
+- **[microsoft/azure-ai-translation-document-py](https://officialskills.sh/microsoft/skills/azure-ai-translation-document-py)** - Batch document translation
+- **[microsoft/azure-ai-translation-text-py](https://officialskills.sh/microsoft/skills/azure-ai-translation-text-py)** - Real-time text translation
+- **[microsoft/azure-ai-vision-imageanalysis-py](https://officialskills.sh/microsoft/skills/azure-ai-vision-imageanalysis-py)** - Image captions, tags, OCR, objects
+- **[microsoft/azure-ai-voicelive-py](https://officialskills.sh/microsoft/skills/azure-ai-voicelive-py)** - Real-time bidirectional voice AI
+- **[microsoft/azure-appconfiguration-py](https://officialskills.sh/microsoft/skills/azure-appconfiguration-py)** - Feature flags and dynamic settings
+- **[microsoft/azure-containerregistry-py](https://officialskills.sh/microsoft/skills/azure-containerregistry-py)** - Container image and registry management
+- **[microsoft/azure-cosmos-db-py](https://officialskills.sh/microsoft/skills/azure-cosmos-db-py)** - Cosmos DB with Python/FastAPI patterns
+- **[microsoft/azure-cosmos-py](https://officialskills.sh/microsoft/skills/azure-cosmos-py)** - Cosmos DB NoSQL client library
+- **[microsoft/azure-data-tables-py](https://officialskills.sh/microsoft/skills/azure-data-tables-py)** - NoSQL key-value table storage
+- **[microsoft/azure-eventgrid-py](https://officialskills.sh/microsoft/skills/azure-eventgrid-py)** - Event-driven pub/sub routing
+- **[microsoft/azure-eventhub-py](https://officialskills.sh/microsoft/skills/azure-eventhub-py)** - High-throughput event streaming
+- **[microsoft/azure-identity-py](https://officialskills.sh/microsoft/skills/azure-identity-py)** - Microsoft Entra ID authentication
+- **[microsoft/azure-keyvault-py](https://officialskills.sh/microsoft/skills/azure-keyvault-py)** - Secrets, keys, and certificate management
+- **[microsoft/azure-messaging-webpubsubservice-py](https://officialskills.sh/microsoft/skills/azure-messaging-webpubsubservice-py)** - Real-time WebSocket messaging
+- **[microsoft/azure-mgmt-apicenter-py](https://officialskills.sh/microsoft/skills/azure-mgmt-apicenter-py)** - API inventory and governance
+- **[microsoft/azure-mgmt-apimanagement-py](https://officialskills.sh/microsoft/skills/azure-mgmt-apimanagement-py)** - API Management service administration
+- **[microsoft/azure-mgmt-botservice-py](https://officialskills.sh/microsoft/skills/azure-mgmt-botservice-py)** - Bot Service resource management
+- **[microsoft/azure-mgmt-fabric-py](https://officialskills.sh/microsoft/skills/azure-mgmt-fabric-py)** - Microsoft Fabric capacity management
+- **[microsoft/azure-monitor-ingestion-py](https://officialskills.sh/microsoft/skills/azure-monitor-ingestion-py)** - Custom log ingestion to Azure Monitor
+- **[microsoft/azure-monitor-opentelemetry-exporter-py](https://officialskills.sh/microsoft/skills/azure-monitor-opentelemetry-exporter-py)** - OpenTelemetry export to Application Insights
+- **[microsoft/azure-monitor-opentelemetry-py](https://officialskills.sh/microsoft/skills/azure-monitor-opentelemetry-py)** - One-line Application Insights setup
+- **[microsoft/azure-monitor-query-py](https://officialskills.sh/microsoft/skills/azure-monitor-query-py)** - Query Azure Monitor logs and metrics
+- **[microsoft/azure-search-documents-py](https://officialskills.sh/microsoft/skills/azure-search-documents-py)** - Full-text, vector, and hybrid search
+- **[microsoft/azure-servicebus-py](https://officialskills.sh/microsoft/skills/azure-servicebus-py)** - Enterprise messaging with queues and topics
+- **[microsoft/azure-speech-to-text-rest-py](https://officialskills.sh/microsoft/skills/azure-speech-to-text-rest-py)** - REST speech-to-text for short audio
+- **[microsoft/azure-storage-blob-py](https://officialskills.sh/microsoft/skills/azure-storage-blob-py)** - Blob object storage client
+- **[microsoft/azure-storage-file-datalake-py](https://officialskills.sh/microsoft/skills/azure-storage-file-datalake-py)** - Hierarchical data lake storage
+- **[microsoft/azure-storage-file-share-py](https://officialskills.sh/microsoft/skills/azure-storage-file-share-py)** - SMB file share management
+- **[microsoft/azure-storage-queue-py](https://officialskills.sh/microsoft/skills/azure-storage-queue-py)** - Simple message queuing
+- **[microsoft/fastapi-router-py](https://officialskills.sh/microsoft/skills/fastapi-router-py)** - FastAPI routers with CRUD and auth
+- **[microsoft/m365-agents-py](https://officialskills.sh/microsoft/skills/m365-agents-py)** - M365, Teams, and Copilot Studio agents
+- **[microsoft/pydantic-models-py](https://officialskills.sh/microsoft/skills/pydantic-models-py)** - Pydantic models for API schemas
+
+### Rust Skills
+
+- **[microsoft/azure-cosmos-rust](https://officialskills.sh/microsoft/skills/azure-cosmos-rust)** - Cosmos DB NoSQL client
+- **[microsoft/azure-eventhub-rust](https://officialskills.sh/microsoft/skills/azure-eventhub-rust)** - Event Hubs streaming client
+- **[microsoft/azure-identity-rust](https://officialskills.sh/microsoft/skills/azure-identity-rust)** - Microsoft Entra ID authentication
+- **[microsoft/azure-keyvault-certificates-rust](https://officialskills.sh/microsoft/skills/azure-keyvault-certificates-rust)** - Key Vault certificate management
+- **[microsoft/azure-keyvault-keys-rust](https://officialskills.sh/microsoft/skills/azure-keyvault-keys-rust)** - Key Vault cryptographic key management
+- **[microsoft/azure-keyvault-secrets-rust](https://officialskills.sh/microsoft/skills/azure-keyvault-secrets-rust)** - Key Vault secret storage
+- **[microsoft/azure-storage-blob-rust](https://officialskills.sh/microsoft/skills/azure-storage-blob-rust)** - Blob object storage client
+
+### TypeScript Skills
+
+- **[microsoft/azure-ai-contentsafety-ts](https://officialskills.sh/microsoft/skills/azure-ai-contentsafety-ts)** - Content safety for text and images
+- **[microsoft/azure-ai-document-intelligence-ts](https://officialskills.sh/microsoft/skills/azure-ai-document-intelligence-ts)** - Document text and table extraction
+- **[microsoft/azure-ai-projects-ts](https://officialskills.sh/microsoft/skills/azure-ai-projects-ts)** - AI Foundry project client and agents
+- **[microsoft/azure-ai-translation-ts](https://officialskills.sh/microsoft/skills/azure-ai-translation-ts)** - Text and document translation
+- **[microsoft/azure-ai-voicelive-ts](https://officialskills.sh/microsoft/skills/azure-ai-voicelive-ts)** - Real-time bidirectional voice AI
+- **[microsoft/azure-appconfiguration-ts](https://officialskills.sh/microsoft/skills/azure-appconfiguration-ts)** - App config, feature flags, dynamic refresh
+- **[microsoft/azure-cosmos-ts](https://officialskills.sh/microsoft/skills/azure-cosmos-ts)** - Cosmos DB NoSQL CRUD and queries
+- **[microsoft/azure-eventhub-ts](https://officialskills.sh/microsoft/skills/azure-eventhub-ts)** - High-throughput event streaming
+- **[microsoft/azure-identity-ts](https://officialskills.sh/microsoft/skills/azure-identity-ts)** - Microsoft Entra ID authentication
+- **[microsoft/azure-keyvault-keys-ts](https://officialskills.sh/microsoft/skills/azure-keyvault-keys-ts)** - Cryptographic key management
+- **[microsoft/azure-keyvault-secrets-ts](https://officialskills.sh/microsoft/skills/azure-keyvault-secrets-ts)** - Secret storage and retrieval
+- **[microsoft/azure-microsoft-playwright-testing-ts](https://officialskills.sh/microsoft/skills/azure-microsoft-playwright-testing-ts)** - Playwright tests at scale on Azure
+- **[microsoft/azure-monitor-opentelemetry-ts](https://officialskills.sh/microsoft/skills/azure-monitor-opentelemetry-ts)** - Application Insights tracing and metrics
+- **[microsoft/azure-postgres-ts](https://officialskills.sh/microsoft/skills/azure-postgres-ts)** - PostgreSQL Flexible Server connection
+- **[microsoft/azure-search-documents-ts](https://officialskills.sh/microsoft/skills/azure-search-documents-ts)** - Vector/hybrid search with semantic ranking
+- **[microsoft/azure-servicebus-ts](https://officialskills.sh/microsoft/skills/azure-servicebus-ts)** - Messaging with queues and topics
+- **[microsoft/azure-storage-blob-ts](https://officialskills.sh/microsoft/skills/azure-storage-blob-ts)** - Blob upload, download, and management
+- **[microsoft/azure-storage-file-share-ts](https://officialskills.sh/microsoft/skills/azure-storage-file-share-ts)** - SMB file share operations
+- **[microsoft/azure-storage-queue-ts](https://officialskills.sh/microsoft/skills/azure-storage-queue-ts)** - Queue message operations
+- **[microsoft/azure-web-pubsub-ts](https://officialskills.sh/microsoft/skills/azure-web-pubsub-ts)** - Real-time WebSocket pub/sub messaging
+- **[microsoft/frontend-ui-dark-ts](https://officialskills.sh/microsoft/skills/frontend-ui-dark-ts)** - Dark-themed React with Tailwind and animations
+- **[microsoft/m365-agents-ts](https://officialskills.sh/microsoft/skills/m365-agents-ts)** - M365, Teams, and Copilot Studio agents
+- **[microsoft/react-flow-node-ts](https://officialskills.sh/microsoft/skills/react-flow-node-ts)** - React Flow node components with Zustand
+- **[microsoft/zustand-store-ts](https://officialskills.sh/microsoft/skills/zustand-store-ts)** - Zustand stores with middleware patterns
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Skills by fal.ai Team</h3></summary>
+
+- **[fal-ai-community/fal-3d](https://officialskills.sh/fal-ai-community/skills/fal-3d)** - Generate 3D models from text or images
+- **[fal-ai-community/fal-audio](https://officialskills.sh/fal-ai-community/skills/fal-audio)** - Text-to-speech and speech-to-text using fal.ai audio models
+- **[fal-ai-community/fal-generate](https://officialskills.sh/fal-ai-community/skills/fal-generate)** - Generate images and videos using fal.ai AI models
+- **[fal-ai-community/fal-image-edit](https://officialskills.sh/fal-ai-community/skills/fal-image-edit)** - AI-powered image editing with style transfer and object removal
+- **[fal-ai-community/fal-kling-o3](https://officialskills.sh/fal-ai-community/skills/fal-kling-o3)** - Generate images and videos with Kling O3 — Kling's most powerful model family
+- **[fal-ai-community/fal-lip-sync](https://officialskills.sh/fal-ai-community/skills/fal-lip-sync)** - Create talking head videos and lip sync audio to video
+- **[fal-ai-community/fal-platform](https://officialskills.sh/fal-ai-community/skills/fal-platform)** - Platform APIs for model management, pricing, and usage tracking
+- **[fal-ai-community/fal-realtime](https://officialskills.sh/fal-ai-community/skills/fal-realtime)** - Real-time and streaming AI image generation
+- **[fal-ai-community/fal-restore](https://officialskills.sh/fal-ai-community/skills/fal-restore)** - Restore and fix image quality — deblur, denoise, fix faces, restore documents
+- **[fal-ai-community/fal-train](https://officialskills.sh/fal-ai-community/skills/fal-train)** - Train custom AI models (LoRA) on fal.ai for personalized image generation
+- **[fal-ai-community/fal-tryon](https://officialskills.sh/fal-ai-community/skills/fal-tryon)** - Virtual try-on — see how clothes look on a person
+- **[fal-ai-community/fal-upscale](https://officialskills.sh/fal-ai-community/skills/fal-upscale)** - Upscale and enhance image and video resolution using AI
+- **[fal-ai-community/fal-video-edit](https://officialskills.sh/fal-ai-community/skills/fal-video-edit)** - Edit existing videos using AI — remix style, upscale, remove background, add audio
+- **[fal-ai-community/fal-vision](https://officialskills.sh/fal-ai-community/skills/fal-vision)** - Analyze images — segment objects, detect, OCR, describe, visual Q&A
+- **[fal-ai-community/fal-workflow](https://officialskills.sh/fal-ai-community/skills/fal-workflow)** - Generate workflow JSON files for chaining AI models
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Skills by WordPress Development Team</h3></summary>
+
+- **[WordPress/wordpress-router](https://officialskills.sh/WordPress/skills/wordpress-router)** - Classifies WordPress repos and routes to the right workflow
+- **[WordPress/wp-project-triage](https://officialskills.sh/WordPress/skills/wp-project-triage)** - Detects project type, tooling, and versions automatically
+- **[WordPress/wp-block-development](https://officialskills.sh/WordPress/skills/wp-block-development)** - Gutenberg blocks: block.json, attributes, rendering, deprecations
+- **[WordPress/wp-block-themes](https://officialskills.sh/WordPress/skills/wp-block-themes)** - Block themes: theme.json, templates, patterns, style variations
+- **[WordPress/wp-plugin-development](https://officialskills.sh/WordPress/skills/wp-plugin-development)** - Plugin architecture, hooks, settings API, security
+- **[WordPress/wp-rest-api](https://officialskills.sh/WordPress/skills/wp-rest-api)** - REST API routes/endpoints, schema, auth, and response shaping
+- **[WordPress/wp-interactivity-api](https://officialskills.sh/WordPress/skills/wp-interactivity-api)** - Frontend interactivity with data-wp-* directives and stores
+- **[WordPress/wp-abilities-api](https://officialskills.sh/WordPress/skills/wp-abilities-api)** - Capability-based permissions and REST API authentication
+- **[WordPress/wp-wpcli-and-ops](https://officialskills.sh/WordPress/skills/wp-wpcli-and-ops)** - WP-CLI commands, automation, multisite, search-replace
+- **[WordPress/wp-performance](https://officialskills.sh/WordPress/skills/wp-performance)** - Profiling, caching, database optimization, Server-Timing
+- **[WordPress/wp-phpstan](https://officialskills.sh/WordPress/skills/wp-phpstan)** - PHPStan static analysis for WordPress projects
+- **[WordPress/wp-playground](https://officialskills.sh/WordPress/skills/wp-playground)** - WordPress Playground for instant local environments
+- **[WordPress/wpds](https://officialskills.sh/WordPress/skills/wpds)** - WordPress Design System
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Skills by OpenAI</h3></summary>
+
+Official curated skills from OpenAI's skills repository.
+
+- **[openai/cloudflare-deploy](https://officialskills.sh/openai/skills/cloudflare-deploy)** - Deploy apps to Cloudflare using Workers, Pages, and platform services
+- **[openai/develop-web-game](https://officialskills.sh/openai/skills/develop-web-game)** - Build and test web games iteratively using Playwright with time-stepping
+- **[openai/doc](https://officialskills.sh/openai/skills/doc)** - Read, create, and edit .docx documents with formatting and layout fidelity
+- **[openai/gh-address-comments](https://officialskills.sh/openai/skills/gh-address-comments)** - Address review and issue comments on open GitHub PRs via CLI
+- **[openai/gh-fix-ci](https://officialskills.sh/openai/skills/gh-fix-ci)** - Debug and fix failing GitHub Actions PR checks using log inspection
+- **[openai/imagegen](https://officialskills.sh/openai/skills/imagegen)** - Generate and edit images using OpenAI's Image API for projects
+- **[openai/jupyter-notebook](https://officialskills.sh/openai/skills/jupyter-notebook)** - Create clean, reproducible Jupyter notebooks for experiments and tutorials
+- **[openai/linear](https://officialskills.sh/openai/skills/linear)** - Manage issues, projects, and team workflows in Linear
+- **[openai/netlify-deploy](https://officialskills.sh/openai/skills/netlify-deploy)** - Automate Netlify deployments with CLI auth, linking, and environment support
+- **[openai/notion-knowledge-capture](https://officialskills.sh/openai/skills/notion-knowledge-capture)** - Convert conversations into structured, searchable Notion wiki entries
+- **[openai/notion-meeting-intelligence](https://officialskills.sh/openai/skills/notion-meeting-intelligence)** - Prep meetings by pulling Notion context and tailoring agendas
+- **[openai/notion-research-documentation](https://officialskills.sh/openai/skills/notion-research-documentation)** - Research Notion content and synthesize findings into structured briefs
+- **[openai/notion-spec-to-implementation](https://officialskills.sh/openai/skills/notion-spec-to-implementation)** - Convert Notion specs into linked implementation plans and tasks
+- **[openai/openai-docs](https://officialskills.sh/openai/skills/openai-docs)** - Provide authoritative guidance from OpenAI developer documentation
+- **[openai/pdf](https://officialskills.sh/openai/skills/pdf)** - Read, create, and review PDFs with layout and visual formatting integrity
+- **[openai/playwright](https://officialskills.sh/openai/skills/playwright)** - Automate real browser interactions for navigation, forms, and scraping
+- **[openai/render-deploy](https://officialskills.sh/openai/skills/render-deploy)** - Deploy applications to Render's cloud platform using Git-backed services
+- **[openai/screenshot](https://officialskills.sh/openai/skills/screenshot)** - Capture desktop, app windows, or pixel regions across OS platforms
+- **[openai/security-best-practices](https://officialskills.sh/openai/skills/security-best-practices)** - Review code for language-specific security vulnerabilities
+- **[openai/security-ownership-map](https://officialskills.sh/openai/skills/security-ownership-map)** - Map people-to-file ownership, compute bus factor, and identify risks
+- **[openai/security-threat-model](https://officialskills.sh/openai/skills/security-threat-model)** - Generate repo-specific threat models identifying trust boundaries
+- **[openai/sentry](https://officialskills.sh/openai/skills/sentry)** - Inspect Sentry issues, summarize production errors, and pull health data
+- **[openai/sora](https://officialskills.sh/openai/skills/sora)** - Generate, remix, and manage short video clips via OpenAI's Sora API
+- **[openai/speech](https://officialskills.sh/openai/skills/speech)** - Generate spoken audio from text using OpenAI's API with built-in voices
+- **[openai/spreadsheet](https://officialskills.sh/openai/skills/spreadsheet)** - Create, edit, analyze, and visualize spreadsheets with formulas
+- **[openai/transcribe](https://officialskills.sh/openai/skills/transcribe)** - Transcribe audio files to text with optional speaker diarization
+- **[openai/vercel-deploy](https://officialskills.sh/openai/skills/vercel-deploy)** - Deploy applications and websites to Vercel with preview or production options
+- **[openai/yeet](https://officialskills.sh/openai/skills/yeet)** - Stage, commit, push code, and open a GitHub pull request via CLI
+- **[openai/aspnet-core](https://officialskills.sh/openai/skills/aspnet-core)** - Build, review, and architect ASP.NET Core apps (Blazor, MVC, Minimal APIs, etc.)
+- **[openai/chatgpt-apps](https://officialskills.sh/openai/skills/chatgpt-apps)** - Build, scaffold, and troubleshoot ChatGPT Apps SDK apps with MCP server and widget UI
+- **[openai/figma](https://officialskills.sh/openai/skills/figma)** - Use the Figma MCP server to fetch design context and translate nodes into production code
+- **[openai/figma-code-connect-components](https://officialskills.sh/openai/skills/figma-code-connect-components)** - Connect Figma design components to code components using Code Connect
+- **[openai/figma-create-design-system-rules](https://officialskills.sh/openai/skills/figma-create-design-system-rules)** - Rules for implementing Figma designs using the Figma MCP server
+- **[openai/figma-create-new-file](https://officialskills.sh/openai/skills/figma-create-new-file)** - Create a new blank Figma file or FigJam file
+- **[openai/figma-generate-design](https://officialskills.sh/openai/skills/figma-generate-design)** - Translate app pages and layouts into Figma using design system tokens
+- **[openai/figma-generate-library](https://officialskills.sh/openai/skills/figma-generate-library)** - Build or update a professional-grade design system in Figma from a codebase
+- **[openai/figma-implement-design](https://officialskills.sh/openai/skills/figma-implement-design)** - Translate Figma designs into production-ready code with 1:1 visual fidelity
+- **[openai/figma-use](https://officialskills.sh/openai/skills/figma-use)** - Prerequisite skill for every use_figma tool call — write/read actions in Figma context
+- **[openai/frontend-skill](https://officialskills.sh/openai/skills/frontend-skill)** - Create visually strong landing pages, websites, and app UIs with restrained composition
+- **[openai/playwright-interactive](https://officialskills.sh/openai/skills/playwright-interactive)** - Persistent browser and Electron interaction via js_repl for iterative UI debugging
+- **[openai/slides](https://officialskills.sh/openai/skills/slides)** - Create and edit .pptx presentation decks with PptxGenJS
+- **[openai/winui-app](https://officialskills.sh/openai/skills/winui-app)** - Bootstrap and develop modern WinUI 3 desktop apps with C# and Windows App SDK
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Skills by Figma</h3></summary>
+
+Official skills from Figma's MCP server guide.
+
+- **[figma/figma-code-connect-components](https://officialskills.sh/figma/skills/figma-code-connect-components)** - Connect Figma design components to code components using Code Connect
+- **[figma/figma-create-design-system-rules](https://officialskills.sh/figma/skills/figma-create-design-system-rules)** - Generate project-specific design system rules for Figma-to-code workflows
+- **[figma/figma-create-new-file](https://officialskills.sh/figma/skills/figma-create-new-file)** - Create a new blank Figma Design or FigJam file
+- **[figma/figma-generate-design](https://officialskills.sh/figma/skills/figma-generate-design)** - Build or update screens in Figma from code or description using design system components
+- **[figma/figma-generate-library](https://officialskills.sh/figma/skills/figma-generate-library)** - Build or update a design system library in Figma from a codebase
+- **[figma/figma-implement-design](https://officialskills.sh/figma/skills/figma-implement-design)** - Translate Figma designs into production-ready application code with 1:1 fidelity
+- **[figma/figma-use](https://officialskills.sh/figma/skills/figma-use)** - Run Figma Plugin API scripts for canvas writes, inspections, variables, and design-system work
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Marketing Skills by Corey Haines</h3></summary>
+
+Official marketing skills by [Corey Haines](https://github.com/coreyhaines31), covering the full SaaS marketing stack from SEO and copywriting to growth, CRO, and paid acquisition.
+
+- **[coreyhaines31/ab-test-setup](https://github.com/coreyhaines31/marketingskills/tree/main/skills/ab-test-setup)** - Plan and implement A/B tests or experiments for any digital experience
+- **[coreyhaines31/ad-creative](https://github.com/coreyhaines31/marketingskills/tree/main/skills/ad-creative)** - Generate and iterate ad creative including headlines, descriptions, and primary text
+- **[coreyhaines31/ai-seo](https://github.com/coreyhaines31/marketingskills/tree/main/skills/ai-seo)** - Optimize content to appear in AI-generated answers and LLM search results
+- **[coreyhaines31/analytics-tracking](https://github.com/coreyhaines31/marketingskills/tree/main/skills/analytics-tracking)** - Set up and audit analytics tracking and measurement pipelines
+- **[coreyhaines31/churn-prevention](https://github.com/coreyhaines31/marketingskills/tree/main/skills/churn-prevention)** - Build cancellation flows, save offers, and recover failed payments
+- **[coreyhaines31/cold-email](https://github.com/coreyhaines31/marketingskills/tree/main/skills/cold-email)** - Write B2B cold emails and follow-up sequences that convert
+- **[coreyhaines31/competitor-alternatives](https://github.com/coreyhaines31/marketingskills/tree/main/skills/competitor-alternatives)** - Build competitor comparison and alternative landing pages for SEO
+- **[coreyhaines31/content-strategy](https://github.com/coreyhaines31/marketingskills/tree/main/skills/content-strategy)** - Plan content strategy and decide what topics and formats to prioritize
+- **[coreyhaines31/copy-editing](https://github.com/coreyhaines31/marketingskills/tree/main/skills/copy-editing)** - Edit and improve existing marketing copy for clarity and impact
+- **[coreyhaines31/copywriting](https://github.com/coreyhaines31/marketingskills/tree/main/skills/copywriting)** - Write and rewrite marketing copy for landing pages, homepages, and ads
+- **[coreyhaines31/email-sequence](https://github.com/coreyhaines31/marketingskills/tree/main/skills/email-sequence)** - Build email sequences, drip campaigns, and lifecycle email flows
+- **[coreyhaines31/form-cro](https://github.com/coreyhaines31/marketingskills/tree/main/skills/form-cro)** - Optimize lead capture and contact forms to improve conversion
+- **[coreyhaines31/free-tool-strategy](https://github.com/coreyhaines31/marketingskills/tree/main/skills/free-tool-strategy)** - Plan and build free tools for lead generation and SEO value
+- **[coreyhaines31/launch-strategy](https://github.com/coreyhaines31/marketingskills/tree/main/skills/launch-strategy)** - Plan product launches, feature announcements, and go-to-market strategies
+- **[coreyhaines31/marketing-ideas](https://github.com/coreyhaines31/marketingskills/tree/main/skills/marketing-ideas)** - Generate marketing strategies and campaign ideas for SaaS products
+- **[coreyhaines31/marketing-psychology](https://github.com/coreyhaines31/marketingskills/tree/main/skills/marketing-psychology)** - Apply psychological principles and behavioral science to copy and design
+- **[coreyhaines31/onboarding-cro](https://github.com/coreyhaines31/marketingskills/tree/main/skills/onboarding-cro)** - Optimize post-signup onboarding and user activation to improve time-to-value
+- **[coreyhaines31/page-cro](https://github.com/coreyhaines31/marketingskills/tree/main/skills/page-cro)** - Improve conversion rates on any marketing page including homepages and landing pages
+- **[coreyhaines31/paid-ads](https://github.com/coreyhaines31/marketingskills/tree/main/skills/paid-ads)** - Create and optimize paid campaigns on Google, Meta, LinkedIn, and more
+- **[coreyhaines31/paywall-upgrade-cro](https://github.com/coreyhaines31/marketingskills/tree/main/skills/paywall-upgrade-cro)** - Design and optimize upgrade screens, paywalls, and upsell modals
+- **[coreyhaines31/popup-cro](https://github.com/coreyhaines31/marketingskills/tree/main/skills/popup-cro)** - Create and optimize popups, modals, and slide-ins for conversions
+- **[coreyhaines31/pricing-strategy](https://github.com/coreyhaines31/marketingskills/tree/main/skills/pricing-strategy)** - Define pricing, packaging, and monetization strategy for SaaS products
+- **[coreyhaines31/product-marketing-context](https://github.com/coreyhaines31/marketingskills/tree/main/skills/product-marketing-context)** - Create and maintain a product marketing context document for consistent messaging
+- **[coreyhaines31/programmatic-seo](https://github.com/coreyhaines31/marketingskills/tree/main/skills/programmatic-seo)** - Build SEO-driven page templates for large-scale content generation
+- **[coreyhaines31/referral-program](https://github.com/coreyhaines31/marketingskills/tree/main/skills/referral-program)** - Design and optimize referral, affiliate, and word-of-mouth programs
+- **[coreyhaines31/revops](https://github.com/coreyhaines31/marketingskills/tree/main/skills/revops)** - Streamline revenue operations, lead lifecycle, and marketing-to-sales handoff
+- **[coreyhaines31/sales-enablement](https://github.com/coreyhaines31/marketingskills/tree/main/skills/sales-enablement)** - Create pitch decks, one-pagers, objection handling docs, and demo scripts
+- **[coreyhaines31/schema-markup](https://github.com/coreyhaines31/marketingskills/tree/main/skills/schema-markup)** - Add and optimize schema markup and structured data for better SEO
+- **[coreyhaines31/seo-audit](https://github.com/coreyhaines31/marketingskills/tree/main/skills/seo-audit)** - Audit and diagnose technical and on-page SEO issues on a site
+- **[coreyhaines31/signup-flow-cro](https://github.com/coreyhaines31/marketingskills/tree/main/skills/signup-flow-cro)** - Optimize signup, registration, and trial activation flows for higher conversion
+- **[coreyhaines31/site-architecture](https://github.com/coreyhaines31/marketingskills/tree/main/skills/site-architecture)** - Plan and restructure page hierarchy, navigation, and URL structure
+- **[coreyhaines31/social-content](https://github.com/coreyhaines31/marketingskills/tree/main/skills/social-content)** - Create and schedule social media content for LinkedIn, Twitter/X, and Instagram
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Advertising Skills by Kim Barrett</h3></summary>
+
+Direct-response advertising skills by Kim Barrett, organized into foundations, copy-chief, operator-os, orchestrators, and QA — covering avatar work, offer design, Schwartz-style copywriting, creative testing, and full-funnel campaign orchestration.
+
+- **[realkimbarrett/avatar-extraction](https://github.com/realkimbarrett/advertising-skills/tree/main/skills/foundations/avatar-extraction)** - Define exactly who the buyer is, what they want, what they've tried, and what's driving their decisions
+- **[realkimbarrett/offer-extraction](https://github.com/realkimbarrett/advertising-skills/tree/main/skills/foundations/offer-extraction)** - Turn a product or service into a compelling, high-converting offer
+- **[realkimbarrett/schwartz-awareness-mapper](https://github.com/realkimbarrett/advertising-skills/tree/main/skills/copy-chief/schwartz-awareness-mapper)** - Determine audience awareness level and the correct messaging approach
+- **[realkimbarrett/mechanism-builder](https://github.com/realkimbarrett/advertising-skills/tree/main/skills/copy-chief/mechanism-builder)** - Explain why your solution works and others failed with a unique mechanism
+- **[realkimbarrett/headline-matrix](https://github.com/realkimbarrett/advertising-skills/tree/main/skills/copy-chief/headline-matrix)** - Generate high-performing headline variations across different angles
+- **[realkimbarrett/objection-crusher](https://github.com/realkimbarrett/advertising-skills/tree/main/skills/copy-chief/objection-crusher)** - Identify and neutralize buyer objections and hesitation
+- **[realkimbarrett/ad-angle-multiplier](https://github.com/realkimbarrett/advertising-skills/tree/main/skills/operator-os/ad-angle-multiplier)** - Expand a core idea into multiple distinct ad angles for creative testing
+- **[realkimbarrett/scroll-stopping-creative](https://github.com/realkimbarrett/advertising-skills/tree/main/skills/operator-os/scroll-stopping-creative)** - Create ad concepts that stop attention in the first 3 seconds
+- **[realkimbarrett/conversion-path-builder](https://github.com/realkimbarrett/advertising-skills/tree/main/skills/operator-os/conversion-path-builder)** - Design the optimal funnel from click to conversion and booked calls
+- **[realkimbarrett/performance-diagnosis](https://github.com/realkimbarrett/advertising-skills/tree/main/skills/operator-os/performance-diagnosis)** - Diagnose why campaigns are underperforming — low conversion, high CPL, bad ads
+- **[realkimbarrett/full-funnel-campaign-orchestrator](https://github.com/realkimbarrett/advertising-skills/tree/main/skills/orchestrators/full-funnel-campaign-orchestrator)** - Coordinate all skills to build a complete ads + funnel campaign end-to-end
+- **[realkimbarrett/generic-language-killer](https://github.com/realkimbarrett/advertising-skills/tree/main/skills/qa/generic-language-killer)** - Remove vague, corporate, or AI-sounding language and replace it with clear, specific, human wording
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Skills by Binance</h3></summary>
+
+Official Web3 and trading skills from the Binance team. Includes crypto market data, on-chain analytics, token security auditing, and spot trading via the Binance API.
+
+- **[binance/crypto-market-rank](https://officialskills.sh/binance/skills/crypto-market-rank)** - Query crypto market rankings including trending tokens, smart money inflows, meme rankings, and top trader PnL leaderboards
+- **[binance/meme-rush](https://officialskills.sh/binance/skills/meme-rush)** - Track real-time meme token lists from launchpads (Pump.fun, Four.meme) and AI-powered hot market topics ranked by net inflow
+- **[binance/query-address-info](https://officialskills.sh/binance/skills/query-address-info)** - Retrieve all token holdings and portfolio positions for any wallet address on BSC, Base, or Solana
+- **[binance/query-token-audit](https://officialskills.sh/binance/skills/query-token-audit)** - Audit token security to detect scams, honeypots, and malicious contracts across BSC, Base, Solana, and Ethereum
+- **[binance/query-token-info](https://officialskills.sh/binance/skills/query-token-info)** - Search tokens and fetch metadata, real-time market data, and K-Line candlestick charts by keyword or contract address
+- **[binance/trading-signal](https://officialskills.sh/binance/skills/trading-signal)** - Monitor on-chain Smart Money buy/sell signals with price, max gain, and exit rate data on Solana and BSC
+- **[binance/spot](https://officialskills.sh/binance/skills/spot)** - Place and manage spot trading orders on Binance via API key authentication, supporting mainnet and testnet
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Skills by Apollo GraphQL</h3></summary>
+
+Official skills from the Apollo GraphQL team for building GraphQL clients, servers, federated supergraphs, and the Apollo Router.
+
+- **[apollographql/apollo-client](https://officialskills.sh/apollographql/skills/apollo-client)** - Build React applications with Apollo Client 4
+- **[apollographql/apollo-connectors](https://officialskills.sh/apollographql/skills/apollo-connectors)** - Integrate REST APIs into GraphQL supergraphs using Apollo Connectors
+- **[apollographql/apollo-federation](https://officialskills.sh/apollographql/skills/apollo-federation)** - Write Apollo Federation 2 subgraph schemas and compose them into a supergraph
+- **[apollographql/apollo-kotlin](https://officialskills.sh/apollographql/skills/apollo-kotlin)** - A GraphQL client for Android, JVM, and Kotlin Multiplatform projects
+- **[apollographql/apollo-mcp-server](https://officialskills.sh/apollographql/skills/apollo-mcp-server)** - Connect AI agents to GraphQL APIs through the Model Context Protocol
+- **[apollographql/apollo-router](https://officialskills.sh/apollographql/skills/apollo-router)** - Version-aware configuration generator for the Rust-based Apollo Router
+- **[apollographql/apollo-router-plugin-creator](https://officialskills.sh/apollographql/skills/apollo-router-plugin-creator)** - Write native Rust plugins for Apollo Router
+- **[apollographql/apollo-server](https://officialskills.sh/apollographql/skills/apollo-server)** - Build GraphQL servers using Apollo Server 5
+- **[apollographql/graphql-operations](https://officialskills.sh/apollographql/skills/graphql-operations)** - Write GraphQL queries, mutations, and subscriptions following best practices
+- **[apollographql/graphql-schema](https://officialskills.sh/apollographql/skills/graphql-schema)** - Reference guide for designing clean, evolvable GraphQL schemas
+- **[apollographql/rover](https://officialskills.sh/apollographql/skills/rover)** - CLI tool for managing GraphQL schemas in Apollo GraphOS
+- **[apollographql/rust-best-practices](https://officialskills.sh/apollographql/skills/rust-best-practices)** - Rust coding guidelines drawn from Apollo GraphQL's internal handbook
+- **[apollographql/skill-creator](https://officialskills.sh/apollographql/skills/skill-creator)** - Create and structure Agent Skills focused on Apollo GraphQL
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Skills by Auth0</h3></summary>
+
+Official authentication and identity skills from the Auth0 team. Covers SDKs for popular frameworks plus workflows for MFA, migration, and quickstart detection.
+
+- **[auth0/auth0-android](https://officialskills.sh/auth0/skills/auth0-android)** - Add authentication to native Android apps using the Auth0 SDK
+- **[auth0/auth0-angular](https://officialskills.sh/auth0/skills/auth0-angular)** - Add authentication to Angular apps using @auth0/auth0-angular
+- **[auth0/auth0-aspnetcore-api](https://officialskills.sh/auth0/skills/auth0-aspnetcore-api)** - Add JWT access token validation to ASP.NET Core APIs
+- **[auth0/auth0-express](https://officialskills.sh/auth0/skills/auth0-express)** - Add session-based authentication to Express.js apps
+- **[auth0/auth0-fastify](https://officialskills.sh/auth0/skills/auth0-fastify)** - Add session-based authentication to Fastify web apps
+- **[auth0/auth0-fastify-api](https://officialskills.sh/auth0/skills/auth0-fastify-api)** - Secure Fastify API endpoints with JWT Bearer token validation
+- **[auth0/auth0-mfa](https://officialskills.sh/auth0/skills/auth0-mfa)** - Add Multi-Factor Authentication to Auth0-powered apps
+- **[auth0/auth0-migration](https://officialskills.sh/auth0/skills/auth0-migration)** - Migrate users and auth flows from other providers to Auth0
+- **[auth0/auth0-nextjs](https://officialskills.sh/auth0/skills/auth0-nextjs)** - Add authentication to Next.js apps
+- **[auth0/auth0-nuxt](https://officialskills.sh/auth0/skills/auth0-nuxt)** - Add Auth0 authentication to Nuxt 3/4 apps with encrypted cookie sessions
+- **[auth0/auth0-quickstart](https://officialskills.sh/auth0/skills/auth0-quickstart)** - Detect your framework and scaffold Auth0 integration automatically
+- **[auth0/auth0-react](https://officialskills.sh/auth0/skills/auth0-react)** - Add authentication to React SPAs using @auth0/auth0-react
+- **[auth0/auth0-react-native](https://officialskills.sh/auth0/skills/auth0-react-native)** - Add authentication to React Native and Expo mobile apps
+- **[auth0/auth0-vue](https://officialskills.sh/auth0/skills/auth0-vue)** - Add authentication to Vue.js apps
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Skills by Brave</h3></summary>
+
+Official skills from the Brave team for accessing Brave Search APIs including web, images, videos, news, and local point-of-interest data.
+
+- **[brave/answers](https://officialskills.sh/brave/skills/answers)** - AI-generated answers grounded in live web search results
+- **[brave/bx](https://officialskills.sh/brave/skills/bx)** - CLI tool for web search built for AI agents
+- **[brave/images-search](https://officialskills.sh/brave/skills/images-search)** - Search for images using the Brave Search API
+- **[brave/llm-context](https://officialskills.sh/brave/skills/llm-context)** - Return pre-extracted web content (text, tables, code) from Brave Search
+- **[brave/local-descriptions](https://officialskills.sh/brave/skills/local-descriptions)** - Fetch AI-generated text descriptions for points of interest
+- **[brave/local-pois](https://officialskills.sh/brave/skills/local-pois)** - Retrieve detailed local business and POI information
+- **[brave/news-search](https://officialskills.sh/brave/skills/news-search)** - Search Brave's news index with article metadata
+- **[brave/spellcheck](https://officialskills.sh/brave/skills/spellcheck)** - Check search queries for spelling errors and get corrections
+- **[brave/suggest](https://officialskills.sh/brave/skills/suggest)** - Query autocomplete suggestions via the Brave Search API
+- **[brave/videos-search](https://officialskills.sh/brave/skills/videos-search)** - Search for videos across the web via the Brave Search API
+- **[brave/web-search](https://officialskills.sh/brave/skills/web-search)** - Search the web via Brave's Search API with ranked results
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Skills by Browserbase</h3></summary>
+
+Official browser automation skills from the Browserbase team. Covers headless browsing, cookie sync, serverless functions, and adversarial UI testing.
+
+- **[browserbase/browser](https://officialskills.sh/browserbase/skills/browser)** - Automate web browser interactions through natural language CLI commands
+- **[browserbase/browserbase-cli](https://officialskills.sh/browserbase/skills/browserbase-cli)** - CLI wrapper around the Browserbase platform
+- **[browserbase/cookie-sync](https://officialskills.sh/browserbase/skills/cookie-sync)** - Export cookies from local Chrome into a Browserbase persistent context
+- **[browserbase/fetch](https://officialskills.sh/browserbase/skills/fetch)** - Fetch HTML, JSON, headers, and status codes through the Browserbase API
+- **[browserbase/functions](https://officialskills.sh/browserbase/skills/functions)** - Deploy browser automation scripts as serverless cloud functions
+- **[browserbase/search](https://officialskills.sh/browserbase/skills/search)** - Search the web via the Browserbase API with structured results
+- **[browserbase/ui-test](https://officialskills.sh/browserbase/skills/ui-test)** - Run adversarial UI tests by analyzing git diffs in a real browser
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Skills by CodeRabbit</h3></summary>
+
+Official AI code review skills from the CodeRabbit team.
+
+- **[coderabbitai/autofix](https://officialskills.sh/coderabbitai/skills/autofix)** - Fetch unresolved CodeRabbit review comments from GitHub PRs and apply fixes
+- **[coderabbitai/code-review](https://officialskills.sh/coderabbitai/skills/code-review)** - Run AI-powered code reviews through the CodeRabbit CLI
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Skills by Coinbase</h3></summary>
+
+Official wallet, payments, and trading skills from the Coinbase team. Covers USDC transfers, onchain queries, x402 paid APIs, and Base trading.
+
+- **[coinbase/authenticate-wallet](https://officialskills.sh/coinbase/skills/authenticate-wallet)** - Handle sign-in for the Coinbase payments wallet via email OTP
+- **[coinbase/fund](https://officialskills.sh/coinbase/skills/fund)** - Add USDC to a Coinbase-powered wallet through Coinbase Onramp
+- **[coinbase/monetize-service](https://officialskills.sh/coinbase/skills/monetize-service)** - Scaffold an Express server that charges USDC per request using x402
+- **[coinbase/pay-for-service](https://officialskills.sh/coinbase/skills/pay-for-service)** - Call paid API endpoints that use the x402 protocol with automatic USDC
+- **[coinbase/query-onchain-data](https://officialskills.sh/coinbase/skills/query-onchain-data)** - Query decoded onchain data (events, tx, blocks) on Base
+- **[coinbase/search-for-service](https://officialskills.sh/coinbase/skills/search-for-service)** - Search and browse the x402 bazaar marketplace
+- **[coinbase/send-usdc](https://officialskills.sh/coinbase/skills/send-usdc)** - Send USDC to any Ethereum address or ENS name on Base
+- **[coinbase/trade](https://officialskills.sh/coinbase/skills/trade)** - Swap and trade tokens on Base using the CDP Swap API
+- **[coinbase/x402](https://officialskills.sh/coinbase/skills/x402)** - Discover and call paid API endpoints using the x402 payment protocol
+
+</details>
+
+
+<details>
+<summary><h3 style="display:inline">Skills by Datadog Labs</h3></summary>
+
+Observability skills from Datadog Labs for APM, logs, monitors, and LLM observability workflows powered by the pup CLI.
+
+- **[datadog-labs/dd-apm](https://officialskills.sh/datadog-labs/skills/dd-apm)** - Query Datadog APM data directly from your editor
+- **[datadog-labs/dd-docs](https://officialskills.sh/datadog-labs/skills/dd-docs)** - Look up Datadog documentation via the LLM-optimized docs index
+- **[datadog-labs/dd-llmo-eval-bootstrap](https://officialskills.sh/datadog-labs/skills/dd-llmo-eval-bootstrap)** - Analyze production LLM traces and generate evaluators
+- **[datadog-labs/dd-llmo-eval-trace-rca](https://officialskills.sh/datadog-labs/skills/dd-llmo-eval-trace-rca)** - Root-cause LLM app failures using eval traces
+- **[datadog-labs/dd-llmo-experiment-analyzer](https://officialskills.sh/datadog-labs/skills/dd-llmo-experiment-analyzer)** - Analyze single or comparative LLM experiment results
+- **[datadog-labs/dd-logs](https://officialskills.sh/datadog-labs/skills/dd-logs)** - Search, filter, and archive Datadog logs through pup CLI
+- **[datadog-labs/dd-monitors](https://officialskills.sh/datadog-labs/skills/dd-monitors)** - Manage Datadog monitors through the pup CLI
+- **[datadog-labs/dd-pup](https://officialskills.sh/datadog-labs/skills/dd-pup)** - Rust-based CLI (pup) for talking to the Datadog API
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Skills by Firebase</h3></summary>
+
+Official skills from the Firebase team for setup, auth, Firestore, hosting, Genkit AI SDKs, and security rule auditing.
+
+- **[firebase/developing-genkit-dart](https://officialskills.sh/firebase/skills/developing-genkit-dart)** - Build AI apps with the Genkit Dart SDK
+- **[firebase/developing-genkit-go](https://officialskills.sh/firebase/skills/developing-genkit-go)** - Build AI apps with the Genkit Go SDK
+- **[firebase/developing-genkit-js](https://officialskills.sh/firebase/skills/developing-genkit-js)** - Build AI-powered apps with Firebase Genkit in Node.js
+- **[firebase/firebase-ai-logic-basics](https://officialskills.sh/firebase/skills/firebase-ai-logic-basics)** - Call Gemini models from web and mobile apps via Firebase AI Logic
+- **[firebase/firebase-app-hosting-basics](https://officialskills.sh/firebase/skills/firebase-app-hosting-basics)** - Deploy and manage full-stack web apps (Next.js, Angular, etc.)
+- **[firebase/firebase-auth-basics](https://officialskills.sh/firebase/skills/firebase-auth-basics)** - Set up Firebase Authentication with sign-in providers
+- **[firebase/firebase-basics](https://officialskills.sh/firebase/skills/firebase-basics)** - Handle Firebase CLI install, auth, and day-to-day workflow
+- **[firebase/firebase-data-connect-basics](https://officialskills.sh/firebase/skills/firebase-data-connect-basics)** - Build Firebase Data Connect backends backed by Cloud SQL
+- **[firebase/firebase-firestore-enterprise-native-mode](https://officialskills.sh/firebase/skills/firebase-firestore-enterprise-native-mode)** - Set up and use Firestore Enterprise Native Mode
+- **[firebase/firebase-firestore-standard](https://officialskills.sh/firebase/skills/firebase-firestore-standard)** - Complete guide for Cloud Firestore Standard Edition
+- **[firebase/firebase-hosting-basics](https://officialskills.sh/firebase/skills/firebase-hosting-basics)** - Deploy static sites, SPAs, and microservices to Firebase Hosting
+- **[firebase/firebase-security-rules-auditor](https://officialskills.sh/firebase/skills/firebase-security-rules-auditor)** - Audit Firestore security rules and flag risky patterns
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Skills by Flutter</h3></summary>
+
+Official skills from the Flutter team covering layouts, state, navigation, native interop, platform setup, and testing for cross-platform Flutter apps.
+
+- **[flutter/flutter-adding-home-screen-widgets](https://officialskills.sh/flutter/skills/flutter-adding-home-screen-widgets)** - Add home screen widgets to Flutter apps on Android and iOS
+- **[flutter/flutter-animating-apps](https://officialskills.sh/flutter/skills/flutter-animating-apps)** - Implement animated effects, transitions, and motion
+- **[flutter/flutter-architecting-apps](https://officialskills.sh/flutter/skills/flutter-architecting-apps)** - Structure a Flutter app using layered architecture
+- **[flutter/flutter-building-forms](https://officialskills.sh/flutter/skills/flutter-building-forms)** - Build Flutter forms with validation and user input
+- **[flutter/flutter-building-layouts](https://officialskills.sh/flutter/skills/flutter-building-layouts)** - Build and fix layouts using the constraint system (Row, Column, Stack)
+- **[flutter/flutter-building-plugins](https://officialskills.sh/flutter/skills/flutter-building-plugins)** - Create Flutter plugins that bridge Dart with platform code
+- **[flutter/flutter-caching-data](https://officialskills.sh/flutter/skills/flutter-caching-data)** - Implement offline-first caching strategies
+- **[flutter/flutter-embedding-native-views](https://officialskills.sh/flutter/skills/flutter-embedding-native-views)** - Embed native Android, iOS, and macOS views in Flutter widgets
+- **[flutter/flutter-handling-concurrency](https://officialskills.sh/flutter/skills/flutter-handling-concurrency)** - Run heavy work in background Dart isolates
+- **[flutter/flutter-handling-http-and-json](https://officialskills.sh/flutter/skills/flutter-handling-http-and-json)** - Handle HTTP requests and JSON serialization
+- **[flutter/flutter-implementing-navigation-and-routing](https://officialskills.sh/flutter/skills/flutter-implementing-navigation-and-routing)** - Handle routing, navigation, and deep linking
+- **[flutter/flutter-improving-accessibility](https://officialskills.sh/flutter/skills/flutter-improving-accessibility)** - Configure Flutter for screen readers and assistive tech
+- **[flutter/flutter-interoperating-with-native-apis](https://officialskills.sh/flutter/skills/flutter-interoperating-with-native-apis)** - Bridge Flutter with native platform APIs
+- **[flutter/flutter-localizing-apps](https://officialskills.sh/flutter/skills/flutter-localizing-apps)** - Configure Flutter for multiple languages and regions
+- **[flutter/flutter-managing-state](https://officialskills.sh/flutter/skills/flutter-managing-state)** - Manage local widget state and shared application state
+- **[flutter/flutter-reducing-app-size](https://officialskills.sh/flutter/skills/flutter-reducing-app-size)** - Measure and optimize Flutter app bundle sizes
+- **[flutter/flutter-setting-up-on-linux](https://officialskills.sh/flutter/skills/flutter-setting-up-on-linux)** - Set up a Linux machine for Flutter desktop development
+- **[flutter/flutter-setting-up-on-macos](https://officialskills.sh/flutter/skills/flutter-setting-up-on-macos)** - Set up a macOS machine for Flutter development
+- **[flutter/flutter-setting-up-on-windows](https://officialskills.sh/flutter/skills/flutter-setting-up-on-windows)** - Set up a Windows machine for Flutter development
+- **[flutter/flutter-testing-apps](https://officialskills.sh/flutter/skills/flutter-testing-apps)** - Implement unit, widget, and integration tests
+- **[flutter/flutter-theming-apps](https://officialskills.sh/flutter/skills/flutter-theming-apps)** - Customize Flutter app appearance through the theming system
+- **[flutter/flutter-working-with-databases](https://officialskills.sh/flutter/skills/flutter-working-with-databases)** - Build a structured data layer using SQLite
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Product Manager Skills by Dean Peters</h3></summary>
+
+46 battle-tested product management skills by [Dean Peters](https://github.com/deanpeters). Frame problems, hunt opportunities, scaffold validation experiments, and kill bad bets fast — with frameworks from Teresa Torres, Geoffrey Moore, Amazon, MITRE, and more.
+
+**Component Skills**
+
+- **[deanpeters/acquisition-channel-advisor](https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/acquisition-channel-advisor)** - Evaluate channels using unit economics and recommend scale/test/kill decisions
+- **[deanpeters/ai-shaped-readiness-advisor](https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/ai-shaped-readiness-advisor)** - Assess automation vs. redesign opportunities across five competencies
+- **[deanpeters/altitude-horizon-framework](https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/altitude-horizon-framework)** - Navigate the PM→Director mindset shift covering scope, time horizons, and failure modes
+- **[deanpeters/business-health-diagnostic](https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/business-health-diagnostic)** - Diagnose SaaS health, identify red flags, and prioritize recovery actions
+- **[deanpeters/company-research](https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/company-research)** - Deep-dive competitor or company analysis
+- **[deanpeters/customer-journey-map](https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/customer-journey-map)** - Map customer experience across touchpoints using the NNGroup framework
+- **[deanpeters/eol-message](https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/eol-message)** - Communicate product or feature deprecation gracefully
+- **[deanpeters/epic-hypothesis](https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/epic-hypothesis)** - Turn initiatives into testable hypotheses with measurable success metrics
+- **[deanpeters/finance-metrics-quickref](https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/finance-metrics-quickref)** - Reference guide for 32+ SaaS finance metrics with formulas and benchmarks
+- **[deanpeters/jobs-to-be-done](https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/jobs-to-be-done)** - Understand customer objectives using the JTBD framework
+- **[deanpeters/pestel-analysis](https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/pestel-analysis)** - Analyze external factors across Political, Economic, Social, Tech, Environmental, and Legal dimensions
+- **[deanpeters/pol-probe](https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/pol-probe)** - Define lightweight validation experiments to test hypotheses
+- **[deanpeters/positioning-statement](https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/positioning-statement)** - Define target audience, problem solved, and differentiation using Geoffrey Moore's framework
+- **[deanpeters/press-release](https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/press-release)** - Clarify product vision with a future press release using Amazon's Working Backwards method
+- **[deanpeters/problem-statement](https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/problem-statement)** - Frame customer problems with evidence before jumping to solutions
+- **[deanpeters/proto-persona](https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/proto-persona)** - Create hypothesis-driven personas before conducting full research
+- **[deanpeters/recommendation-canvas](https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/recommendation-canvas)** - Document AI-powered product recommendations
+- **[deanpeters/saas-economics-efficiency-metrics](https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/saas-economics-efficiency-metrics)** - Calculate unit economics and capital efficiency including CAC, LTV, payback, and Rule of 40
+- **[deanpeters/saas-revenue-growth-metrics](https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/saas-revenue-growth-metrics)** - Track revenue, retention, and growth metrics including MRR/ARR, churn, NRR, and expansion
+- **[deanpeters/storyboard](https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/storyboard)** - Visualize user journeys with 6-frame narrative storyboards
+- **[deanpeters/user-story](https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/user-story)** - Write user stories with acceptance criteria using Mike Cohn and Gherkin formats
+- **[deanpeters/user-story-mapping](https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/user-story-mapping)** - Organize stories by user workflow using Jeff Patton's story mapping approach
+- **[deanpeters/user-story-splitting](https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/user-story-splitting)** - Break down large stories using 8 proven splitting patterns
+
+**Interactive Skills**
+
+- **[deanpeters/context-engineering-advisor](https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/context-engineering-advisor)** - Diagnose context stuffing vs. engineering and guide memory and retrieval design
+- **[deanpeters/customer-journey-mapping-workshop](https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/customer-journey-mapping-workshop)** - Guide journey mapping sessions with pain point identification
+- **[deanpeters/director-readiness-advisor](https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/director-readiness-advisor)** - Coach the PM→Director transition across four key situations
+- **[deanpeters/discovery-interview-prep](https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/discovery-interview-prep)** - Plan customer interviews using Mom Test style based on research goals
+- **[deanpeters/epic-breakdown-advisor](https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/epic-breakdown-advisor)** - Split epics into stories using Richard Lawrence's 9 splitting patterns
+- **[deanpeters/feature-investment-advisor](https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/feature-investment-advisor)** - Evaluate features using ROI and strategic value scoring
+- **[deanpeters/finance-based-pricing-advisor](https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/finance-based-pricing-advisor)** - Evaluate pricing changes using financial impact analysis
+- **[deanpeters/lean-ux-canvas](https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/lean-ux-canvas)** - Set up hypothesis-driven planning using Jeff Gothelf's Lean UX Canvas v2
+- **[deanpeters/opportunity-solution-tree](https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/opportunity-solution-tree)** - Generate opportunities and solutions and recommend proof-of-concept tests
+- **[deanpeters/pol-probe-advisor](https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/pol-probe-advisor)** - Recommend prototype type: Feasibility, Task-Focused, Narrative, Synthetic, or Vibe
+- **[deanpeters/positioning-workshop](https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/positioning-workshop)** - Guide positioning definition with adaptive discovery questions
+- **[deanpeters/prioritization-advisor](https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/prioritization-advisor)** - Recommend the right prioritization framework (RICE, ICE, Kano, etc.) for your situation
+- **[deanpeters/problem-framing-canvas](https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/problem-framing-canvas)** - Lead through MITRE Problem Framing: Look Inward, Outward, and Reframe
+- **[deanpeters/tam-sam-som-calculator](https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/tam-sam-som-calculator)** - Project market size with real-world data and citations
+- **[deanpeters/user-story-mapping-workshop](https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/user-story-mapping-workshop)** - Walk through creating story maps with backbone and release slices
+- **[deanpeters/vp-cpo-readiness-advisor](https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/vp-cpo-readiness-advisor)** - Coach the Director→VP/CPO transition including a CEO interview framework
+- **[deanpeters/workshop-facilitation](https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/workshop-facilitation)** - Add step-by-step facilitation with numbered recommendations to any workshop
+
+**Workflow Skills**
+
+- **[deanpeters/discovery-process](https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/discovery-process)** - Full discovery cycle: frame problem → research → synthesize → validate (3-4 weeks)
+- **[deanpeters/executive-onboarding-playbook](https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/executive-onboarding-playbook)** - 30-60-90 day diagnostic playbook for VP/CPO onboarding transitions
+- **[deanpeters/prd-development](https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/prd-development)** - Structured PRD process: problem → personas → solution → metrics → stories (2-4 days)
+- **[deanpeters/product-strategy-session](https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/product-strategy-session)** - Full strategy session: positioning → framing → exploration → roadmap (2-4 weeks)
+- **[deanpeters/roadmap-planning](https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/roadmap-planning)** - Strategic roadmap process: inputs → epics → prioritize → sequence → communicate (1-2 weeks)
+- **[deanpeters/skill-authoring-workflow](https://github.com/deanpeters/Product-Manager-Skills/tree/main/skills/skill-authoring-workflow)** - Meta workflow for authoring skills: choose path → validate → update docs → package
+
+</details>
+
+
+<details>
+<summary><h3 style="display:inline">Product Management Skills by Pawel Huryn</h3></summary>
+
+65 product management skills by [Paweł Huryn](https://github.com/phuryn), creator of The Product Compass newsletter. Covers the full PM lifecycle — from discovery and strategy to execution, analytics, and go-to-market — with frameworks from Teresa Torres, Geoffrey Moore, and more.
+
+**Data Analytics**
+
+- **[phuryn/ab-test-analysis](https://github.com/phuryn/pm-skills/tree/main/pm-data-analytics/skills/ab-test-analysis)** - Analyze A/B test results with statistical significance and recommendations
+- **[phuryn/cohort-analysis](https://github.com/phuryn/pm-skills/tree/main/pm-data-analytics/skills/cohort-analysis)** - Cohort retention curves, feature adoption, and segment insights
+- **[phuryn/sql-queries](https://github.com/phuryn/pm-skills/tree/main/pm-data-analytics/skills/sql-queries)** - Generate SQL queries from natural language across major dialects
+
+**Execution**
+
+- **[phuryn/brainstorm-okrs](https://github.com/phuryn/pm-skills/tree/main/pm-execution/skills/brainstorm-okrs)** - Brainstorm team OKRs aligned with company objectives
+- **[phuryn/create-prd](https://github.com/phuryn/pm-skills/tree/main/pm-execution/skills/create-prd)** - Create a PRD with 8-section template covering problem to release
+- **[phuryn/dummy-dataset](https://github.com/phuryn/pm-skills/tree/main/pm-execution/skills/dummy-dataset)** - Generate realistic dummy datasets in CSV, JSON, or SQL
+- **[phuryn/job-stories](https://github.com/phuryn/pm-skills/tree/main/pm-execution/skills/job-stories)** - Create job stories with acceptance criteria in JTBD format
+- **[phuryn/outcome-roadmap](https://github.com/phuryn/pm-skills/tree/main/pm-execution/skills/outcome-roadmap)** - Transform output roadmaps into outcome-focused strategic plans
+- **[phuryn/pre-mortem](https://github.com/phuryn/pm-skills/tree/main/pm-execution/skills/pre-mortem)** - Run pre-mortem risk analysis on PRDs and launch plans
+- **[phuryn/prioritization-frameworks](https://github.com/phuryn/pm-skills/tree/main/pm-execution/skills/prioritization-frameworks)** - Reference guide to 9 prioritization frameworks with templates
+- **[phuryn/release-notes](https://github.com/phuryn/pm-skills/tree/main/pm-execution/skills/release-notes)** - Generate user-facing release notes from tickets or changelogs
+- **[phuryn/retro](https://github.com/phuryn/pm-skills/tree/main/pm-execution/skills/retro)** - Facilitate structured sprint retrospectives with action items
+- **[phuryn/sprint-plan](https://github.com/phuryn/pm-skills/tree/main/pm-execution/skills/sprint-plan)** - Plan sprints with capacity, story selection, and risk mapping
+- **[phuryn/stakeholder-map](https://github.com/phuryn/pm-skills/tree/main/pm-execution/skills/stakeholder-map)** - Build stakeholder maps with power/interest grid and comms plan
+- **[phuryn/summarize-meeting](https://github.com/phuryn/pm-skills/tree/main/pm-execution/skills/summarize-meeting)** - Summarize meeting transcripts into structured notes and actions
+- **[phuryn/test-scenarios](https://github.com/phuryn/pm-skills/tree/main/pm-execution/skills/test-scenarios)** - Create comprehensive test scenarios from user stories
+- **[phuryn/user-stories](https://github.com/phuryn/pm-skills/tree/main/pm-execution/skills/user-stories)** - Create INVEST-compliant user stories with 3 C's structure
+- **[phuryn/wwas](https://github.com/phuryn/pm-skills/tree/main/pm-execution/skills/wwas)** - Create backlog items in Why-What-Acceptance format
+
+**Go-to-Market**
+
+- **[phuryn/beachhead-segment](https://github.com/phuryn/pm-skills/tree/main/pm-go-to-market/skills/beachhead-segment)** - Identify the first beachhead market segment for product launch
+- **[phuryn/competitive-battlecard](https://github.com/phuryn/pm-skills/tree/main/pm-go-to-market/skills/competitive-battlecard)** - Create sales-ready battlecards against specific competitors
+- **[phuryn/growth-loops](https://github.com/phuryn/pm-skills/tree/main/pm-go-to-market/skills/growth-loops)** - Identify growth loops across 5 flywheel types for traction
+- **[phuryn/gtm-motions](https://github.com/phuryn/pm-skills/tree/main/pm-go-to-market/skills/gtm-motions)** - Identify best GTM motions across 7 types including PLG and ABM
+- **[phuryn/gtm-strategy](https://github.com/phuryn/pm-skills/tree/main/pm-go-to-market/skills/gtm-strategy)** - Create GTM strategy with channels, messaging, and launch timeline
+- **[phuryn/ideal-customer-profile](https://github.com/phuryn/pm-skills/tree/main/pm-go-to-market/skills/ideal-customer-profile)** - Identify ICP with demographics, behaviors, and JTBD
+
+**Market Research**
+
+- **[phuryn/competitor-analysis](https://github.com/phuryn/pm-skills/tree/main/pm-market-research/skills/competitor-analysis)** - Analyze competitors with strengths, weaknesses, and differentiation
+- **[phuryn/customer-journey-map](https://github.com/phuryn/pm-skills/tree/main/pm-market-research/skills/customer-journey-map)** - Map customer journeys with touchpoints, emotions, and opportunities
+- **[phuryn/market-segments](https://github.com/phuryn/pm-skills/tree/main/pm-market-research/skills/market-segments)** - Identify 3-5 customer segments with JTBD and product fit
+- **[phuryn/market-sizing](https://github.com/phuryn/pm-skills/tree/main/pm-market-research/skills/market-sizing)** - Estimate TAM, SAM, SOM with top-down and bottom-up approaches
+- **[phuryn/sentiment-analysis](https://github.com/phuryn/pm-skills/tree/main/pm-market-research/skills/sentiment-analysis)** - Analyze user feedback with sentiment scores and JTBD insights
+- **[phuryn/user-personas](https://github.com/phuryn/pm-skills/tree/main/pm-market-research/skills/user-personas)** - Create 3 user personas with JTBD, pains, and gains
+- **[phuryn/user-segmentation](https://github.com/phuryn/pm-skills/tree/main/pm-market-research/skills/user-segmentation)** - Segment users by behavior, JTBD, and needs from feedback data
+
+**Marketing & Growth**
+
+- **[phuryn/marketing-ideas](https://github.com/phuryn/pm-skills/tree/main/pm-marketing-growth/skills/marketing-ideas)** - Generate 5 creative, cost-effective marketing ideas with rationale
+- **[phuryn/north-star-metric](https://github.com/phuryn/pm-skills/tree/main/pm-marketing-growth/skills/north-star-metric)** - Define North Star Metric and input metrics constellation
+- **[phuryn/positioning-ideas](https://github.com/phuryn/pm-skills/tree/main/pm-marketing-growth/skills/positioning-ideas)** - Brainstorm positioning ideas differentiated from competitors
+- **[phuryn/product-name](https://github.com/phuryn/pm-skills/tree/main/pm-marketing-growth/skills/product-name)** - Brainstorm 5 memorable product names aligned to brand values
+- **[phuryn/value-prop-statements](https://github.com/phuryn/pm-skills/tree/main/pm-marketing-growth/skills/value-prop-statements)** - Generate value prop statements for marketing, sales, and onboarding
+
+**Product Discovery**
+
+- **[phuryn/analyze-feature-requests](https://github.com/phuryn/pm-skills/tree/main/pm-product-discovery/skills/analyze-feature-requests)** - Prioritize feature requests by theme, impact, effort, and risk
+- **[phuryn/brainstorm-experiments-existing](https://github.com/phuryn/pm-skills/tree/main/pm-product-discovery/skills/brainstorm-experiments-existing)** - Design experiments to test assumptions for existing products
+- **[phuryn/brainstorm-experiments-new](https://github.com/phuryn/pm-skills/tree/main/pm-product-discovery/skills/brainstorm-experiments-new)** - Design lean pretotypes for new product validation
+- **[phuryn/brainstorm-ideas-existing](https://github.com/phuryn/pm-skills/tree/main/pm-product-discovery/skills/brainstorm-ideas-existing)** - Brainstorm product ideas from PM, Designer, Engineer perspectives
+- **[phuryn/brainstorm-ideas-new](https://github.com/phuryn/pm-skills/tree/main/pm-product-discovery/skills/brainstorm-ideas-new)** - Brainstorm feature ideas for new products in early discovery
+- **[phuryn/identify-assumptions-existing](https://github.com/phuryn/pm-skills/tree/main/pm-product-discovery/skills/identify-assumptions-existing)** - Identify risky assumptions across Value, Usability, Viability, Feasibility
+- **[phuryn/identify-assumptions-new](https://github.com/phuryn/pm-skills/tree/main/pm-product-discovery/skills/identify-assumptions-new)** - Identify risky assumptions for new products across 8 risk categories
+- **[phuryn/interview-script](https://github.com/phuryn/pm-skills/tree/main/pm-product-discovery/skills/interview-script)** - Create structured customer interview scripts with JTBD probing
+- **[phuryn/metrics-dashboard](https://github.com/phuryn/pm-skills/tree/main/pm-product-discovery/skills/metrics-dashboard)** - Define product metrics dashboard with sources and alert thresholds
+- **[phuryn/opportunity-solution-tree](https://github.com/phuryn/pm-skills/tree/main/pm-product-discovery/skills/opportunity-solution-tree)** - Build Opportunity Solution Trees based on Teresa Torres' method
+- **[phuryn/prioritize-assumptions](https://github.com/phuryn/pm-skills/tree/main/pm-product-discovery/skills/prioritize-assumptions)** - Prioritize assumptions with Impact × Risk matrix and experiments
+- **[phuryn/prioritize-features](https://github.com/phuryn/pm-skills/tree/main/pm-product-discovery/skills/prioritize-features)** - Prioritize backlog by impact, effort, risk, and strategic alignment
+- **[phuryn/summarize-interview](https://github.com/phuryn/pm-skills/tree/main/pm-product-discovery/skills/summarize-interview)** - Summarize interview transcripts with JTBD and action items
+
+**Product Strategy**
+
+- **[phuryn/ansoff-matrix](https://github.com/phuryn/pm-skills/tree/main/pm-product-strategy/skills/ansoff-matrix)** - Ansoff Matrix analysis across 4 growth strategy quadrants
+- **[phuryn/business-model](https://github.com/phuryn/pm-skills/tree/main/pm-product-strategy/skills/business-model)** - Generate Business Model Canvas with all 9 building blocks
+- **[phuryn/lean-canvas](https://github.com/phuryn/pm-skills/tree/main/pm-product-strategy/skills/lean-canvas)** - Generate Lean Canvas with problem, solution, UVP, and metrics
+- **[phuryn/monetization-strategy](https://github.com/phuryn/pm-skills/tree/main/pm-product-strategy/skills/monetization-strategy)** - Brainstorm 3-5 monetization strategies with validation experiments
+- **[phuryn/pestle-analysis](https://github.com/phuryn/pm-skills/tree/main/pm-product-strategy/skills/pestle-analysis)** - PESTLE analysis across Political, Economic, Social, Tech, Legal, Environmental
+- **[phuryn/porters-five-forces](https://github.com/phuryn/pm-skills/tree/main/pm-product-strategy/skills/porters-five-forces)** - Porter's Five Forces competitive analysis with strategic insights
+- **[phuryn/pricing-strategy](https://github.com/phuryn/pm-skills/tree/main/pm-product-strategy/skills/pricing-strategy)** - Design pricing strategies with competitive analysis and WTP estimation
+- **[phuryn/product-strategy](https://github.com/phuryn/pm-skills/tree/main/pm-product-strategy/skills/product-strategy)** - Create product strategy using 9-section Product Strategy Canvas
+- **[phuryn/product-vision](https://github.com/phuryn/pm-skills/tree/main/pm-product-strategy/skills/product-vision)** - Brainstorm inspiring, achievable product vision statements
+- **[phuryn/startup-canvas](https://github.com/phuryn/pm-skills/tree/main/pm-product-strategy/skills/startup-canvas)** - Generate Startup Canvas combining Product Strategy and Business Model
+- **[phuryn/swot-analysis](https://github.com/phuryn/pm-skills/tree/main/pm-product-strategy/skills/swot-analysis)** - SWOT analysis with actionable recommendations per quadrant
+- **[phuryn/value-proposition](https://github.com/phuryn/pm-skills/tree/main/pm-product-strategy/skills/value-proposition)** - Design value propositions using 6-part JTBD template
+
+**Toolkit**
+
+- **[phuryn/draft-nda](https://github.com/phuryn/pm-skills/tree/main/pm-toolkit/skills/draft-nda)** - Draft NDAs covering information types, jurisdiction, and clauses
+- **[phuryn/grammar-check](https://github.com/phuryn/pm-skills/tree/main/pm-toolkit/skills/grammar-check)** - Identify grammar and flow errors with targeted fix suggestions
+- **[phuryn/privacy-policy](https://github.com/phuryn/pm-skills/tree/main/pm-toolkit/skills/privacy-policy)** - Draft privacy policies with GDPR compliance considerations
+- **[phuryn/review-resume](https://github.com/phuryn/pm-skills/tree/main/pm-toolkit/skills/review-resume)** - PM resume review against 10 best practices including XYZ+S formula
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Skills by MiniMax Team</h3></summary>
+
+11 development and document generation skills from the MiniMax AI team. Covers frontend, fullstack, mobile, shader development, document creation (PDF, DOCX, XLSX, PPTX), and the MiniMax AI CLI with MiniMax API integration.
+
+- **[MiniMax-AI/cli](https://officialskills.sh/MiniMax-AI/skills/cli)** - Generate text, image, video, speech, and music via MiniMax AI
+- **[MiniMax-AI/frontend-dev](https://officialskills.sh/MiniMax-AI/skills/frontend-dev)** - Full-stack frontend with cinematic animations, AI-generated media via MiniMax API, and generative art
+- **[MiniMax-AI/fullstack-dev](https://officialskills.sh/MiniMax-AI/skills/fullstack-dev)** - Backend architecture with REST API design, auth flows, real-time features, and database integration
+- **[MiniMax-AI/android-native-dev](https://officialskills.sh/MiniMax-AI/skills/android-native-dev)** - Android native development with Kotlin/Jetpack Compose, Material Design 3, and accessibility
+- **[MiniMax-AI/ios-application-dev](https://officialskills.sh/MiniMax-AI/skills/ios-application-dev)** - iOS development with UIKit, SnapKit, and SwiftUI covering navigation, Dark Mode, and HIG compliance
+- **[MiniMax-AI/shader-dev](https://officialskills.sh/MiniMax-AI/skills/shader-dev)** - GLSL shader techniques for ray marching, fluid simulation, particle systems, and procedural generation
+- **[MiniMax-AI/gif-sticker-maker](https://officialskills.sh/MiniMax-AI/skills/gif-sticker-maker)** - Convert photos into animated GIF stickers in Funko Pop / Pop Mart style via MiniMax API
+- **[MiniMax-AI/minimax-pdf](https://officialskills.sh/MiniMax-AI/skills/minimax-pdf)** - Generate, fill, and reformat PDFs with a token-based design system and 15 cover styles
+- **[MiniMax-AI/pptx-generator](https://officialskills.sh/MiniMax-AI/skills/pptx-generator)** - Create and edit PowerPoint presentations from scratch with PptxGenJS
+- **[MiniMax-AI/minimax-xlsx](https://officialskills.sh/MiniMax-AI/skills/minimax-xlsx)** - Create, read, analyze, and validate Excel/spreadsheet files with zero format loss
+- **[MiniMax-AI/minimax-docx](https://officialskills.sh/MiniMax-AI/skills/minimax-docx)** - Professional DOCX document creation and editing using OpenXML SDK
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Skills by DuckDB</h3></summary>
+
+Official DuckDB skills for data querying, file reading, and documentation search directly from Claude Code.
+
+- **[duckdb/attach-db](https://officialskills.sh/duckdb/skills/attach-db)** - Attach a DuckDB database file for interactive querying with automatic schema exploration
+- **[duckdb/query](https://officialskills.sh/duckdb/skills/query)** - Run SQL queries against attached databases or ad-hoc against files using Friendly SQL dialect
+- **[duckdb/read-file](https://officialskills.sh/duckdb/skills/read-file)** - Read any data file (CSV, JSON, Parquet, Avro, Excel, spatial) locally or from remote storage
+- **[duckdb/duckdb-docs](https://officialskills.sh/duckdb/skills/duckdb-docs)** - Search DuckDB and DuckLake documentation using full-text search over HTTPS
+- **[duckdb/read-memories](https://officialskills.sh/duckdb/skills/read-memories)** - Search past Claude Code session logs to recover context from previous conversations
+- **[duckdb/install-duckdb](https://officialskills.sh/duckdb/skills/install-duckdb)** - Install or update DuckDB CLI and extensions with version management
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Skills by GSAP (GreenSock)</h3></summary>
+
+Official GSAP animation skills covering the full GreenSock ecosystem — core API, timelines, ScrollTrigger, plugins, utilities, React integration, performance optimization, and framework support.
+
+- **[greensock/gsap-core](https://officialskills.sh/greensock/skills/gsap-core)** - Core API with gsap.to(), from(), fromTo(), easing, duration, stagger, and defaults
+- **[greensock/gsap-timeline](https://officialskills.sh/greensock/skills/gsap-timeline)** - Timelines with sequencing, position parameter, labels, nesting, and playback control
+- **[greensock/gsap-scrolltrigger](https://officialskills.sh/greensock/skills/gsap-scrolltrigger)** - ScrollTrigger for scroll-linked animations, pinning, scrub, and refresh handling
+- **[greensock/gsap-plugins](https://officialskills.sh/greensock/skills/gsap-plugins)** - Plugins including ScrollToPlugin, Flip, Draggable, SplitText, SVG, and physics
+- **[greensock/gsap-utils](https://officialskills.sh/greensock/skills/gsap-utils)** - Utility functions like clamp, mapRange, interpolate, snap, selector, and wrap
+- **[greensock/gsap-react](https://officialskills.sh/greensock/skills/gsap-react)** - React integration with useGSAP hook, refs, gsap.context(), cleanup, and SSR
+- **[greensock/gsap-performance](https://officialskills.sh/greensock/skills/gsap-performance)** - Performance tips for transforms, will-change, batching, and ScrollTrigger optimization
+- **[greensock/gsap-frameworks](https://officialskills.sh/greensock/skills/gsap-frameworks)** - Vue, Svelte, and other frameworks with lifecycle, scoping, and cleanup patterns
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Skills by Garry Tan (gstack)</h3></summary>
+
+28 skills by [Garry Tan](https://github.com/garrytan) (Y Combinator CEO) that transform Claude Code into a virtual engineering team — structured workflows from ideation to production deployment. Ships 600K+ lines of production code in 60 days.
+
+- **[garrytan/office-hours](https://officialskills.sh/garrytan/skills/office-hours)** - YC Office Hours: six forcing questions that reframe your product before you write code
+- **[garrytan/plan-ceo-review](https://officialskills.sh/garrytan/skills/plan-ceo-review)** - CEO/Founder plan review with four modes: Expansion, Selective Expansion, Hold Scope, Reduction
+- **[garrytan/plan-eng-review](https://officialskills.sh/garrytan/skills/plan-eng-review)** - Eng Manager review: lock in architecture, data flow, diagrams, edge cases, and tests
+- **[garrytan/plan-design-review](https://officialskills.sh/garrytan/skills/plan-design-review)** - Senior Designer review: rates each design dimension 0-10, explains what a 10 looks like, AI Slop detection
+- **[garrytan/design-consultation](https://officialskills.sh/garrytan/skills/design-consultation)** - Build a complete design system from scratch with creative risks and realistic product mockups
+- **[garrytan/design-review](https://officialskills.sh/garrytan/skills/design-review)** - Designer Who Codes: visual audit then fixes with atomic commits and before/after screenshots
+- **[garrytan/review](https://officialskills.sh/garrytan/skills/review)** - Staff Engineer code review: finds bugs that pass CI but blow up in production
+- **[garrytan/investigate](https://officialskills.sh/garrytan/skills/investigate)** - Systematic root-cause debugging: no fixes without investigation, traces data flow, tests hypotheses
+- **[garrytan/qa](https://officialskills.sh/garrytan/skills/qa)** - QA Lead: test your app, find bugs, fix them with atomic commits, auto-generate regression tests
+- **[garrytan/qa-only](https://officialskills.sh/garrytan/skills/qa-only)** - QA Reporter: same methodology as /qa but report only, no code changes
+- **[garrytan/cso](https://officialskills.sh/garrytan/skills/cso)** - Chief Security Officer: OWASP Top 10 + STRIDE threat model with zero false-positive exclusions
+- **[garrytan/ship](https://officialskills.sh/garrytan/skills/ship)** - Release Engineer: sync main, run tests, audit coverage, push, open PR
+- **[garrytan/land-and-deploy](https://officialskills.sh/garrytan/skills/land-and-deploy)** - Merge the PR, wait for CI and deploy, verify production health
+- **[garrytan/canary](https://officialskills.sh/garrytan/skills/canary)** - SRE post-deploy monitoring: watches for console errors, performance regressions, and page failures
+- **[garrytan/benchmark](https://officialskills.sh/garrytan/skills/benchmark)** - Performance Engineer: baseline page load times, Core Web Vitals, and resource sizes
+- **[garrytan/document-release](https://officialskills.sh/garrytan/skills/document-release)** - Technical Writer: update all project docs to match what you just shipped
+- **[garrytan/retro](https://officialskills.sh/garrytan/skills/retro)** - Eng Manager weekly retro with per-person breakdowns and shipping streaks
+- **[garrytan/browse](https://officialskills.sh/garrytan/skills/browse)** - Real Chromium browser for QA: real clicks, real screenshots, ~100ms per command
+- **[garrytan/setup-browser-cookies](https://officialskills.sh/garrytan/skills/setup-browser-cookies)** - Import cookies from your real browser into the headless session
+- **[garrytan/autoplan](https://officialskills.sh/garrytan/skills/autoplan)** - One command, fully reviewed plan: runs CEO → design → eng review automatically
+- **[garrytan/codex](https://officialskills.sh/garrytan/skills/codex)** - Second Opinion via OpenAI Codex CLI: review, adversarial challenge, and open consultation
+- **[garrytan/careful](https://officialskills.sh/garrytan/skills/careful)** - Safety Guardrails: warns before destructive commands (rm -rf, DROP TABLE, force-push)
+- **[garrytan/freeze](https://officialskills.sh/garrytan/skills/freeze)** - Edit Lock: restrict file edits to one directory while debugging
+- **[garrytan/guard](https://officialskills.sh/garrytan/skills/guard)** - Full Safety: /careful + /freeze in one command for maximum safety
+- **[garrytan/unfreeze](https://officialskills.sh/garrytan/skills/unfreeze)** - Unlock: remove the /freeze boundary
+- **[garrytan/setup-deploy](https://officialskills.sh/garrytan/skills/setup-deploy)** - Deploy Configurator: one-time setup for /land-and-deploy
+- **[garrytan/gstack-upgrade](https://officialskills.sh/garrytan/skills/gstack-upgrade)** - Self-Updater: upgrade gstack to latest version
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Skills by Notion</h3></summary>
+
+Official skills from Notion's repositories — workspace-aware skills for capturing knowledge, preparing meetings, researching, and turning specs into tasks.
+
+**From [notion-cookbook](https://github.com/makenotion/notion-cookbook/tree/main/skills/claude):**
+
+- **[makenotion/knowledge-capture](https://officialskills.sh/makenotion/skills/knowledge-capture)** - Transform conversations into structured Notion documentation pages with proper organization and linking
+- **[makenotion/meeting-intelligence](https://officialskills.sh/makenotion/skills/meeting-intelligence)** - Prepare meeting materials by gathering Notion context and creating pre-reads and agendas
+- **[makenotion/research-documentation](https://officialskills.sh/makenotion/skills/research-documentation)** - Search Notion workspace, synthesize findings, and create comprehensive research reports
+- **[makenotion/spec-to-implementation](https://officialskills.sh/makenotion/skills/spec-to-implementation)** - Turn product/tech specs into concrete Notion tasks with acceptance criteria and progress tracking
+
+**From [claude-code-notion-plugin](https://github.com/makenotion/claude-code-notion-plugin/tree/main/skills/notion):**
+
+- **[makenotion/knowledge-capture](https://officialskills.sh/makenotion/skills/knowledge-capture)** - Transform conversations into structured Notion documentation pages with proper organization and linking
+- **[makenotion/meeting-intelligence](https://officialskills.sh/makenotion/skills/meeting-intelligence)** - Prepare meeting materials by gathering Notion context and creating pre-reads and agendas
+- **[makenotion/research-documentation](https://officialskills.sh/makenotion/skills/research-documentation)** - Search Notion workspace, synthesize findings, and create comprehensive research reports
+- **[makenotion/spec-to-implementation](https://officialskills.sh/makenotion/skills/spec-to-implementation)** - Turn product/tech specs into concrete Notion tasks with acceptance criteria and progress tracking
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Skills by Resend</h3></summary>
+
+Official Resend skills to send and receive emails, build email templates and power your agent with email expertise.
+
+- **[resend/resend](https://github.com/resend/resend-skills/tree/main/skills/resend)** - Send and manage emails via the Resend API
+- **[resend/react-email](https://github.com/resend/resend-skills/tree/main/skills/react-email)** - Build emails with React Email components
+- **[resend/email-best-practices](https://github.com/resend/resend-skills/tree/main/skills/email-best-practices)** - Email deliverability and design best practices
+- **[resend/agent-email-inbox](https://github.com/resend/resend-skills/tree/main/skills/agent-email-inbox)** - AI agent email inbox management
+- **[resend/resend-cli](https://github.com/resend/resend-skills/tree/main/skills/resend-cli)** - Resend CLI commands and workflows
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Skills by - Google Chrome team - Addy Osmani (Web Quality)</h3></summary>
+
+Lighthouse-style web quality skills from Addy Osmani(Google Chrome team) covering performance, Core Web Vitals, accessibility, SEO, and modern best practices — the same pillars Google Lighthouse audits.
+
+- **[addyosmani/web-quality-audit](https://officialskills.sh/addyosmani/skills/web-quality-audit)** - Comprehensive quality review across performance, accessibility, SEO, and best practices categories
+- **[addyosmani/performance](https://officialskills.sh/addyosmani/skills/performance)** - Loading speed, runtime efficiency, and resource optimization
+- **[addyosmani/core-web-vitals](https://officialskills.sh/addyosmani/skills/core-web-vitals)** - LCP, INP, and CLS-specific optimizations
+- **[addyosmani/accessibility](https://officialskills.sh/addyosmani/skills/accessibility)** - WCAG compliance, screen reader support, and keyboard navigation
+- **[addyosmani/seo](https://officialskills.sh/addyosmani/skills/seo)** - Search engine optimization, crawlability, and structured data
+- **[addyosmani/best-practices](https://officialskills.sh/addyosmani/skills/best-practices)** - Security, modern web APIs, and code quality patterns
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Skills by MongoDB</h3></summary>
+
+Official MongoDB Agent Skills for agentic workflows — connection management, schema design, query optimization, natural language querying, and Atlas Stream Processing.
+
+- **[mongodb/mongodb-mcp-setup](https://officialskills.sh/mongodb/skills/mongodb-mcp-setup)** - Set up the MongoDB MCP server with authentication and connection configuration
+- **[mongodb/mongodb-connection](https://officialskills.sh/mongodb/skills/mongodb-connection)** - Optimize MongoDB client connection pools, timeouts, and serverless patterns
+- **[mongodb/mongodb-schema-design](https://officialskills.sh/mongodb/skills/mongodb-schema-design)** - Design efficient document schemas with validation and indexing patterns
+- **[mongodb/atlas-stream-processing](https://officialskills.sh/mongodb/skills/atlas-stream-processing)** - Build, operate, and debug Atlas Stream Processing pipelines with Kafka, S3, and Lambda integrations
+- **[mongodb/mongodb-natural-language-querying](https://officialskills.sh/mongodb/skills/mongodb-natural-language-querying)** - Translate natural language into MongoDB queries and aggregation pipelines
+- **[mongodb/mongodb-query-optimizer](https://officialskills.sh/mongodb/skills/mongodb-query-optimizer)** - Analyze and optimize query performance using Atlas Performance Advisor
+- **[mongodb/mongodb-search-and-ai](https://officialskills.sh/mongodb/skills/mongodb-search-and-ai)** - Implement Atlas Search and AI-powered recommendations with vector search
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Skills by Redis</h3></summary>
+
+- **[redis/redis-development](https://github.com/redis/agent-skills/tree/main/skills/redis-development)** - Redis development best practices — data structures, query engine, vector search, caching, and performance optimization.
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Skills by NVIDIA</h3></summary>
+
+Official skills published by NVIDIA across AI/ML infrastructure projects — Megatron, NeMo, TensorRT-LLM, CUDA-Q, cuOpt, DALI, DeepStream, and more. 155 skills across 17 products.
+
+### CUDA-Q
+
+- **[NVIDIA/CUDA-Q/cudaq-guide](https://github.com/NVIDIA/skills/tree/main/skills/CUDA-Q/cudaq-guide)** - CUDA-Q onboarding guide for installation, test programs, GPU simulation, QPU hardware, and quantum applications.
+
+### DALI
+
+- **[NVIDIA/DALI/dali-dynamic-mode](https://github.com/NVIDIA/skills/tree/main/skills/DALI/dali-dynamic-mode)** - Use when writing DALI data loading or preprocessing code with `nvidia.dali.experimental.dynamic` (ndd), or when converting DALI pipeline-mode code to dynamic mode, or when the user...
+
+### Megatron-Bridge
+
+- **[NVIDIA/Megatron-Bridge/adding-model-support](https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/adding-model-support)** - Guide for adding support for new LLM or VLM models in Megatron-Bridge.
+- **[NVIDIA/Megatron-Bridge/build-and-dependency](https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/build-and-dependency)** - Dev environment setup for Megatron Bridge — container-based development, uv package management, lockfile regeneration, adding dependencies, Slurm container usage, and common build...
+- **[NVIDIA/Megatron-Bridge/bump-dependency](https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/bump-dependency)** - Bump a pinned dependency (TransformerEngine, Megatron-LM, NRX, etc.), regenerate the lockfile, open a PR, and drive it to green by attaching a watchdog to the "CICD NeMo" workflow...
+- **[NVIDIA/Megatron-Bridge/cicd](https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/cicd)** - CI/CD reference for Megatron Bridge — pipeline structure, commit and PR workflow, CI failure investigation, and common failure patterns.
+- **[NVIDIA/Megatron-Bridge/linting-and-formatting](https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/linting-and-formatting)** - Code style and quality rules for Megatron Bridge — ruff configuration, naming conventions, type hints, mypy rules, docstrings, copyright headers, logging, and the code review check...
+- **[NVIDIA/Megatron-Bridge/mlm-bridge-training](https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/mlm-bridge-training)** - Run Megatron-LM (MLM) and Megatron Bridge training with mock or real data.
+- **[NVIDIA/Megatron-Bridge/multi-node-slurm](https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/multi-node-slurm)** - Convert single-node scripts to multi-node Slurm sbatch jobs and debug common multi-node failures.
+- **[NVIDIA/Megatron-Bridge/nemo-rl-e2e-testing](https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/nemo-rl-e2e-testing)** - External NeMo-RL end-to-end validation workflow for Megatron-Bridge model/provider changes, including downstream compatibility checks, external RL lifecycle behavior, Megatron poli...
+- **[NVIDIA/Megatron-Bridge/parity-testing](https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/parity-testing)** - Structured framework for verifying numerical parity of HF<->MCore weight conversions.
+- **[NVIDIA/Megatron-Bridge/perf-activation-recompute](https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/perf-activation-recompute)** - Validate and use selective and full activation recompute in Megatron Bridge to reduce GPU memory usage at the cost of extra compute.
+- **[NVIDIA/Megatron-Bridge/perf-cpu-offloading](https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/perf-cpu-offloading)** - Validate and use CPU offloading in Megatron Bridge, including layer-level activation offloading and fractional optimizer state offloading with HybridDeviceOptimizer.
+- **[NVIDIA/Megatron-Bridge/perf-cuda-graphs](https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/perf-cuda-graphs)** - Validate and use CUDA graph capture in Megatron Bridge, including local full-iteration graphs and Transformer Engine scoped graphs for attention, MLP, and MoE modules.
+- **[NVIDIA/Megatron-Bridge/perf-expert-parallel-overlap](https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/perf-expert-parallel-overlap)** - Validate and use MoE expert-parallel communication overlap in Megatron-Bridge, including overlap_moe_expert_parallel_comm, delay_wgrad_compute, and flex dispatcher backends such as...
+- **[NVIDIA/Megatron-Bridge/perf-hierarchical-context-parallel](https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/perf-hierarchical-context-parallel)** - Operational guide for enabling hierarchical context parallelism in Megatron-Bridge, including config knobs, code anchors, pitfalls, and verification.
+- **[NVIDIA/Megatron-Bridge/perf-megatron-fsdp](https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/perf-megatron-fsdp)** - Operational guide for enabling Megatron FSDP in Megatron-Bridge, including config knobs, code anchors, pitfalls, and verification.
+- **[NVIDIA/Megatron-Bridge/perf-memory-tuning](https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/perf-memory-tuning)** - Techniques for reducing peak GPU memory in Megatron Bridge — expandable segments, parallelism resizing, activation recompute, CPU offloading constraints, and common OOM fixes.
+- **[NVIDIA/Megatron-Bridge/perf-moe-comm-overlap](https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/perf-moe-comm-overlap)** - MoE expert-parallel communication overlap in Megatron Bridge.
+- **[NVIDIA/Megatron-Bridge/perf-moe-dispatcher-selection](https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/perf-moe-dispatcher-selection)** - Choose the right MoE token dispatcher (`alltoall`, DeepEP, or HybridEP) for the hardware, EP degree, and optimization stage.
+- **[NVIDIA/Megatron-Bridge/perf-moe-hardware-configs](https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/perf-moe-hardware-configs)** - Representative MoE training playbooks by hardware platform and model family.
+- **[NVIDIA/Megatron-Bridge/perf-moe-long-context](https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/perf-moe-long-context)** - Long-context MoE training guidance for Megatron Bridge.
+- **[NVIDIA/Megatron-Bridge/perf-moe-optimization-workflow](https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/perf-moe-optimization-workflow)** - Systematic workflow for MoE training optimization in Megatron Bridge, based on the Megatron-Core MoE paper.
+- **[NVIDIA/Megatron-Bridge/perf-moe-vlm-training](https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/perf-moe-vlm-training)** - Practical guidance for training MoE VLMs in Megatron Bridge.
+- **[NVIDIA/Megatron-Bridge/perf-parallelism-strategies](https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/perf-parallelism-strategies)** - Operational guide for choosing and combining parallelism strategies in Megatron Bridge, including sizing rules, hardware topology mapping, and combined parallelism configuration.
+- **[NVIDIA/Megatron-Bridge/perf-sequence-packing](https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/perf-sequence-packing)** - Validate and use packed sequences and long-context training in Megatron-Bridge, distinguishing offline packed SFT for LLMs from in-batch packing for VLMs, and applying the right CP...
+- **[NVIDIA/Megatron-Bridge/perf-tp-dp-comm-overlap](https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/perf-tp-dp-comm-overlap)** - Operational guide for enabling TP, DP, and PP communication overlap in Megatron-Bridge, including config knobs, code anchors, pitfalls, and verification.
+- **[NVIDIA/Megatron-Bridge/recipe-recommender](https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/recipe-recommender)** - Recommend and customize Megatron Bridge recipes for a user's model, GPU count, and training goal.
+- **[NVIDIA/Megatron-Bridge/resiliency](https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/resiliency)** - Resiliency features in Megatron Bridge including fault tolerance, straggler detection, in-process restart, preemption, and re-run state machine.
+- **[NVIDIA/Megatron-Bridge/testing](https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/testing)** - Testing reference for Megatron Bridge — unit and functional test layout, tier semantics (L0/L1/L2/flaky), script conventions, running tests locally, adding/moving/disabling tests,...
+- **[NVIDIA/Megatron-Bridge/verl-e2e-testing](https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Bridge/verl-e2e-testing)** - External verl end-to-end validation workflow for Megatron-Bridge model/provider changes.
+
+### Megatron-Core
+
+- **[NVIDIA/Megatron-Core/build-and-dependency](https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Core/build-and-dependency)** - Container-based dev environment setup and dependency management for Megatron-LM.
+- **[NVIDIA/Megatron-Core/bump-base-image](https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Core/bump-base-image)** - Bump the NVIDIA PyTorch base image (`nvcr.io/nvidia/pytorch:<YY.MM>-py3`) used by Megatron-LM CI.
+- **[NVIDIA/Megatron-Core/cicd](https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Core/cicd)** - CI/CD reference for Megatron-LM.
+- **[NVIDIA/Megatron-Core/create-issue](https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Core/create-issue)** - Investigate a failing GitHub Actions run or job and create a GitHub issue for the failure.
+- **[NVIDIA/Megatron-Core/linting-and-formatting](https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Core/linting-and-formatting)** - Linting and formatting for Megatron-LM.
+- **[NVIDIA/Megatron-Core/nightly-sync](https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Core/nightly-sync)** - Domain knowledge for the nightly main-to-dev sync workflow.
+- **[NVIDIA/Megatron-Core/onboard-gb200-1node-tests](https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Core/onboard-gb200-1node-tests)** - Onboard 1-node GitHub MR functional tests for GB200 from existing mr-scoped 2-node tests.
+- **[NVIDIA/Megatron-Core/respond-to-issue](https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Core/respond-to-issue)** - Research and draft a response to a GitHub issue or question from an external contributor.
+- **[NVIDIA/Megatron-Core/run-on-slurm](https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Core/run-on-slurm)** - How to launch distributed Megatron-LM training jobs on a SLURM cluster.
+- **[NVIDIA/Megatron-Core/split-pr](https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Core/split-pr)** - Split a PR into multiple PRs to reduce the number of required CODEOWNERS reviewer groups.
+- **[NVIDIA/Megatron-Core/testing](https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Core/testing)** - Test system for Megatron-LM.
+- **[NVIDIA/Megatron-Core/update-golden-values](https://github.com/NVIDIA/skills/tree/main/skills/Megatron-Core/update-golden-values)** - Refresh golden values from a GitHub Actions workflow run (failing-only or all jobs), score the change with average normalized relative differences, and produce a PR-ready summary.
+
+### Model-Optimizer
+
+- **[NVIDIA/Model-Optimizer/accessing-mlflow](https://github.com/NVIDIA/skills/tree/main/skills/Model-Optimizer/accessing-mlflow)** - Query and browse evaluation results stored in MLflow.
+- **[NVIDIA/Model-Optimizer/debug](https://github.com/NVIDIA/skills/tree/main/skills/Model-Optimizer/debug)** - Run commands inside a remote Docker container via the file-based command relay (tools/debugger).
+- **[NVIDIA/Model-Optimizer/deployment](https://github.com/NVIDIA/skills/tree/main/skills/Model-Optimizer/deployment)** - Serve a quantized or unquantized LLM checkpoint as an OpenAI-compatible API endpoint using vLLM, SGLang, or TRT-LLM.
+- **[NVIDIA/Model-Optimizer/evaluation](https://github.com/NVIDIA/skills/tree/main/skills/Model-Optimizer/evaluation)** - Evaluates accuracy of quantized or unquantized LLMs using NeMo Evaluator Launcher (NEL).
+- **[NVIDIA/Model-Optimizer/launching-evals](https://github.com/NVIDIA/skills/tree/main/skills/Model-Optimizer/launching-evals)** - Run, monitor, analyze, and debug LLM evaluations via nemo-evaluator-launcher.
+- **[NVIDIA/Model-Optimizer/monitor](https://github.com/NVIDIA/skills/tree/main/skills/Model-Optimizer/monitor)** - Monitor submitted jobs (PTQ, evaluation, deployment) on SLURM clusters.
+- **[NVIDIA/Model-Optimizer/ptq](https://github.com/NVIDIA/skills/tree/main/skills/Model-Optimizer/ptq)** - This skill should be used when the user asks to "quantize a model", "run PTQ", "post-training quantization", "NVFP4 quantization", "FP8 quantization", "INT8 quantization", "INT4 AW...
+- **[NVIDIA/Model-Optimizer/release-cherry-pick](https://github.com/NVIDIA/skills/tree/main/skills/Model-Optimizer/release-cherry-pick)** - Cherry-pick merged PRs labeled for a release branch into that branch, then open a PR and apply the cherry-pick-done label.
+
+### NeMo-Evaluator
+
+- **[NVIDIA/NeMo-Evaluator/byob](https://github.com/NVIDIA/skills/tree/main/skills/NeMo-Evaluator/byob)** - Create custom LLM evaluation benchmarks using the BYOB decorator framework.
+
+### NeMo-Evaluator-Launcher
+
+- **[NVIDIA/NeMo-Evaluator-Launcher/accessing-mlflow](https://github.com/NVIDIA/skills/tree/main/skills/NeMo-Evaluator-Launcher/accessing-mlflow)** - Query and browse evaluation results stored in MLflow.
+- **[NVIDIA/NeMo-Evaluator-Launcher/launching-evals](https://github.com/NVIDIA/skills/tree/main/skills/NeMo-Evaluator-Launcher/launching-evals)** - Run, monitor, analyze, and debug LLM evaluations via nemo-evaluator-launcher.
+- **[NVIDIA/NeMo-Evaluator-Launcher/nel-assistant](https://github.com/NVIDIA/skills/tree/main/skills/NeMo-Evaluator-Launcher/nel-assistant)** - Interactive config wizard for NeMo Evaluator Launcher (NEL).
+
+### NeMo-Gym
+
+- **[NVIDIA/NeMo-Gym/add-benchmark](https://github.com/NVIDIA/skills/tree/main/skills/NeMo-Gym/add-benchmark)** - > Guide for adding a new benchmark or training environment to NeMo-Gym.
+- **[NVIDIA/NeMo-Gym/nemo-gym-debugging](https://github.com/NVIDIA/skills/tree/main/skills/NeMo-Gym/nemo-gym-debugging)** - >- Use when debugging a Nemo Gym run or reward profiling job.
+- **[NVIDIA/NeMo-Gym/nemo-gym-docs](https://github.com/NVIDIA/skills/tree/main/skills/NeMo-Gym/nemo-gym-docs)** - > Maintain the NeMo Gym Fern docs site — add, update, move, or remove pages under fern/.
+- **[NVIDIA/NeMo-Gym/nemo-gym-pivot-datasets](https://github.com/NVIDIA/skills/tree/main/skills/NeMo-Gym/nemo-gym-pivot-datasets)** - >- Use when creating, validating, or documenting Nemo Gym pivot datasets from rollout, trajectory, chat-completion, Responses API, or tool-call artifacts.
+- **[NVIDIA/NeMo-Gym/nemo-gym-reward-profiling](https://github.com/NVIDIA/skills/tree/main/skills/NeMo-Gym/nemo-gym-reward-profiling)** - >- Use to help users get started with Nemo Gym reward profiling.
+
+### NeMo-RL
+
+- **[NVIDIA/NeMo-RL/auto-research](https://github.com/NVIDIA/skills/tree/main/skills/NeMo-RL/auto-research)** - Autonomous NeMo-RL research agent workflow for directed hypothesis testing and open-ended discovery.
+- **[NVIDIA/NeMo-RL/brev-etiquette](https://github.com/NVIDIA/skills/tree/main/skills/NeMo-RL/brev-etiquette)** - Brev instance operating guidance for NeMo-RL agents working in /home/ubuntu/RL with limited workspace disk, a larger /ephemeral volume, and optional /home/ubuntu/RL/.env secrets.
+- **[NVIDIA/NeMo-RL/build-and-dependency](https://github.com/NVIDIA/skills/tree/main/skills/NeMo-RL/build-and-dependency)** - Build and dependency management for NeMo-RL.
+- **[NVIDIA/NeMo-RL/cicd](https://github.com/NVIDIA/skills/tree/main/skills/NeMo-RL/cicd)** - CI/CD reference for NeMo-RL.
+- **[NVIDIA/NeMo-RL/config-conventions](https://github.com/NVIDIA/skills/tree/main/skills/NeMo-RL/config-conventions)** - Configuration conventions for NeMo-RL.
+- **[NVIDIA/NeMo-RL/contributing](https://github.com/NVIDIA/skills/tree/main/skills/NeMo-RL/contributing)** - Contribution conventions for NeMo-RL.
+- **[NVIDIA/NeMo-RL/copyright](https://github.com/NVIDIA/skills/tree/main/skills/NeMo-RL/copyright)** - NVIDIA copyright header requirements for NeMo-RL.
+- **[NVIDIA/NeMo-RL/docs](https://github.com/NVIDIA/skills/tree/main/skills/NeMo-RL/docs)** - Documentation conventions for NeMo-RL.
+- **[NVIDIA/NeMo-RL/error-handling](https://github.com/NVIDIA/skills/tree/main/skills/NeMo-RL/error-handling)** - Error handling guidelines for NeMo-RL.
+- **[NVIDIA/NeMo-RL/launch-nemo-rl](https://github.com/NVIDIA/skills/tree/main/skills/NeMo-RL/launch-nemo-rl)** - Playbook for launching, monitoring, stopping, and debugging NeMo-RL recipes on a Kubernetes cluster via the nrl-k8s CLI.
+- **[NVIDIA/NeMo-RL/linting-and-formatting](https://github.com/NVIDIA/skills/tree/main/skills/NeMo-RL/linting-and-formatting)** - Code style guidelines for NeMo-RL (Python and shell).
+- **[NVIDIA/NeMo-RL/review-pr](https://github.com/NVIDIA/skills/tree/main/skills/NeMo-RL/review-pr)** - Interactive code review for NVIDIA-NeMo/RL pull requests.
+- **[NVIDIA/NeMo-RL/session-memory](https://github.com/NVIDIA/skills/tree/main/skills/NeMo-RL/session-memory)** - Manage durable working-session memory for coding agents.
+- **[NVIDIA/NeMo-RL/testing](https://github.com/NVIDIA/skills/tree/main/skills/NeMo-RL/testing)** - Testing conventions for NeMo-RL.
+
+### NemoClaw
+
+- **[NVIDIA/NemoClaw/nemoclaw-contributor-create-pr](https://github.com/NVIDIA/skills/tree/main/skills/NemoClaw/nemoclaw-contributor-create-pr)** - Create GitHub pull requests that follow the NemoClaw PR template.
+- **[NVIDIA/NemoClaw/nemoclaw-contributor-update-docs](https://github.com/NVIDIA/skills/tree/main/skills/NemoClaw/nemoclaw-contributor-update-docs)** - Scan recent git commits for changes that affect user-facing behavior, then draft or update the corresponding documentation pages and refresh generated user skills for release prep.
+- **[NVIDIA/NemoClaw/nemoclaw-maintainer-cross-issue-sweep](https://github.com/NVIDIA/skills/tree/main/skills/NemoClaw/nemoclaw-maintainer-cross-issue-sweep)** - Scans other open issues to find ones a given PR may also fix or accidentally break.
+- **[NVIDIA/NemoClaw/nemoclaw-maintainer-cut-release-tag](https://github.com/NVIDIA/skills/tree/main/skills/NemoClaw/nemoclaw-maintainer-cut-release-tag)** - Cut a new semver release — bump all version strings via bump-version.ts, open a release PR, and after merge tag main and push.
+- **[NVIDIA/NemoClaw/nemoclaw-maintainer-day](https://github.com/NVIDIA/skills/tree/main/skills/NemoClaw/nemoclaw-maintainer-day)** - Runs the daytime maintainer loop for NemoClaw, prioritizing items labeled with the current version target.
+- **[NVIDIA/NemoClaw/nemoclaw-maintainer-evening](https://github.com/NVIDIA/skills/tree/main/skills/NemoClaw/nemoclaw-maintainer-evening)** - Runs the end-of-day maintainer handoff for NemoClaw.
+- **[NVIDIA/NemoClaw/nemoclaw-maintainer-find-review-pr](https://github.com/NVIDIA/skills/tree/main/skills/NemoClaw/nemoclaw-maintainer-find-review-pr)** - Finds open GitHub PRs with security and priority-high labels, links each to its issue, detects duplicates (multiple PRs fixing the same issue), and presents a table of review candi...
+- **[NVIDIA/NemoClaw/nemoclaw-maintainer-morning](https://github.com/NVIDIA/skills/tree/main/skills/NemoClaw/nemoclaw-maintainer-morning)** - Runs the morning maintainer standup for NemoClaw.
+- **[NVIDIA/NemoClaw/nemoclaw-maintainer-normalize-title-tags](https://github.com/NVIDIA/skills/tree/main/skills/NemoClaw/nemoclaw-maintainer-normalize-title-tags)** - Normalizes GitHub issue and PR titles by removing any bracketed [NemoClaw] tag case-insensitively, even when the tag appears later in the title.
+- **[NVIDIA/NemoClaw/nemoclaw-maintainer-pr-comparator](https://github.com/NVIDIA/skills/tree/main/skills/NemoClaw/nemoclaw-maintainer-pr-comparator)** - Compares competing PRs that target the same issue and recommends which one to merge.
+- **[NVIDIA/NemoClaw/nemoclaw-maintainer-security-code-review](https://github.com/NVIDIA/skills/tree/main/skills/NemoClaw/nemoclaw-maintainer-security-code-review)** - Performs a comprehensive security review of code changes in a GitHub PR or issue.
+- **[NVIDIA/NemoClaw/nemoclaw-maintainer-triage](https://github.com/NVIDIA/skills/tree/main/skills/NemoClaw/nemoclaw-maintainer-triage)** - AI-assisted label triage for NVIDIA/NemoClaw issues and PRs.
+- **[NVIDIA/NemoClaw/nemoclaw-skills-guide](https://github.com/NVIDIA/skills/tree/main/skills/NemoClaw/nemoclaw-skills-guide)** - Start here.
+- **[NVIDIA/NemoClaw/nemoclaw-user-agent-skills](https://github.com/NVIDIA/skills/tree/main/skills/NemoClaw/nemoclaw-user-agent-skills)** - Describes the agent skills shipped with NemoClaw and how to access them by cloning the repository.
+- **[NVIDIA/NemoClaw/nemoclaw-user-configure-inference](https://github.com/NVIDIA/skills/tree/main/skills/NemoClaw/nemoclaw-user-configure-inference)** - Connects NemoClaw to a local inference server.
+- **[NVIDIA/NemoClaw/nemoclaw-user-configure-security](https://github.com/NVIDIA/skills/tree/main/skills/NemoClaw/nemoclaw-user-configure-security)** - Presents a risk framework for every configurable security control in NemoClaw.
+- **[NVIDIA/NemoClaw/nemoclaw-user-deploy-remote](https://github.com/NVIDIA/skills/tree/main/skills/NemoClaw/nemoclaw-user-deploy-remote)** - Explains how to run NemoClaw on a remote GPU instance, including the deprecated Brev compatibility path and the preferred installer plus onboard flow.
+- **[NVIDIA/NemoClaw/nemoclaw-user-get-started](https://github.com/NVIDIA/skills/tree/main/skills/NemoClaw/nemoclaw-user-get-started)** - Installs NemoClaw, launches a sandbox, and runs the first agent prompt.
+- **[NVIDIA/NemoClaw/nemoclaw-user-manage-policy](https://github.com/NVIDIA/skills/tree/main/skills/NemoClaw/nemoclaw-user-manage-policy)** - Adds, removes, or modifies allowed endpoints in the sandbox policy.
+- **[NVIDIA/NemoClaw/nemoclaw-user-manage-sandboxes](https://github.com/NVIDIA/skills/tree/main/skills/NemoClaw/nemoclaw-user-manage-sandboxes)** - Explains operational tasks after the quickstart: listing sandboxes, status and health checks, logs, diagnostics, port forwards, multiple sandboxes, credential reset, rebuilds, netw...
+- **[NVIDIA/NemoClaw/nemoclaw-user-monitor-sandbox](https://github.com/NVIDIA/skills/tree/main/skills/NemoClaw/nemoclaw-user-monitor-sandbox)** - Inspects sandbox health, traces agent behavior, and diagnoses problems.
+- **[NVIDIA/NemoClaw/nemoclaw-user-overview](https://github.com/NVIDIA/skills/tree/main/skills/NemoClaw/nemoclaw-user-overview)** - Explains how OpenClaw, OpenShell, and NemoClaw form the ecosystem, NemoClaw's position in the stack, what NemoClaw adds beyond the community sandbox, and when to prefer NemoClaw ve...
+- **[NVIDIA/NemoClaw/nemoclaw-user-reference](https://github.com/NVIDIA/skills/tree/main/skills/NemoClaw/nemoclaw-user-reference)** - Describes the NemoClaw plugin and blueprint architecture and how they orchestrate the OpenClaw sandbox.
+
+### TensorRT-LLM
+
+- **[NVIDIA/TensorRT-LLM/ad-accuracy-debug](https://github.com/NVIDIA/skills/tree/main/skills/TensorRT-LLM/ad-accuracy-debug)** - > Debug AutoDeploy accuracy regressions vs a reference score (PyTorch backend or published baseline).
+- **[NVIDIA/TensorRT-LLM/ad-add-fusion-transformation](https://github.com/NVIDIA/skills/tree/main/skills/TensorRT-LLM/ad-add-fusion-transformation)** - > Claude Code skill (trtllm-agent-toolkit): implement or extend TensorRT-LLM AutoDeploy fusion transforms under transform/library/ in a TensorRT-LLM checkout.
+- **[NVIDIA/TensorRT-LLM/ad-conf-check](https://github.com/NVIDIA/skills/tree/main/skills/TensorRT-LLM/ad-conf-check)** - > Check whether AutoDeploy YAML configs were actually applied by analyzing server logs and optionally graph dumps (AD_DUMP_GRAPHS_DIR).
+- **[NVIDIA/TensorRT-LLM/ad-graph-dump](https://github.com/NVIDIA/skills/tree/main/skills/TensorRT-LLM/ad-graph-dump)** - > Enable and interpret TensorRT-LLM AutoDeploy FX graph text dumps via AD_DUMP_GRAPHS_DIR.
+- **[NVIDIA/TensorRT-LLM/ad-layer-visualizer](https://github.com/NVIDIA/skills/tree/main/skills/TensorRT-LLM/ad-layer-visualizer)** - > Visualize a specific transformer decoder layer from an AutoDeploy FX graph text dump as a hierarchical DOT/PNG diagram.
+- **[NVIDIA/TensorRT-LLM/ad-model-onboard](https://github.com/NVIDIA/skills/tree/main/skills/TensorRT-LLM/ad-model-onboard)** - > Translates a HuggingFace model into a prefill-only AutoDeploy custom model using reference custom ops, validates with hierarchical equivalence tests.
+- **[NVIDIA/TensorRT-LLM/exec-local-compile](https://github.com/NVIDIA/skills/tree/main/skills/TensorRT-LLM/exec-local-compile)** - Compile TensorRT-LLM on a compute node inside a Docker container.
+- **[NVIDIA/TensorRT-LLM/exec-slurm-compile](https://github.com/NVIDIA/skills/tree/main/skills/TensorRT-LLM/exec-slurm-compile)** - Compile TensorRT-LLM on a SLURM cluster.
+- **[NVIDIA/TensorRT-LLM/kernel-cute-writing](https://github.com/NVIDIA/skills/tree/main/skills/TensorRT-LLM/kernel-cute-writing)** - > Write and implement GPU kernels using NVIDIA CuTe DSL (CUTLASS 4.x Python API) — NOT for Triton, CUDA C++, or conceptual explanations.
+- **[NVIDIA/TensorRT-LLM/kernel-tileir-optimization](https://github.com/NVIDIA/skills/tree/main/skills/TensorRT-LLM/kernel-tileir-optimization)** - > Optimize existing Triton kernels for NVIDIA TileIR backend on Blackwell GPUs (sm_100+).
+- **[NVIDIA/TensorRT-LLM/kernel-triton-writing](https://github.com/NVIDIA/skills/tree/main/skills/TensorRT-LLM/kernel-triton-writing)** - > ONLY for OpenAI Triton (@triton.jit) kernel development.
+- **[NVIDIA/TensorRT-LLM/perf-analysis](https://github.com/NVIDIA/skills/tree/main/skills/TensorRT-LLM/perf-analysis)** - > Performance analysis coordination workflow.
+- **[NVIDIA/TensorRT-LLM/perf-host-analysis](https://github.com/NVIDIA/skills/tree/main/skills/TensorRT-LLM/perf-host-analysis)** - > Analyze host/CPU overhead in TensorRT-LLM inference from nsys traces.
+- **[NVIDIA/TensorRT-LLM/perf-host-optimization](https://github.com/NVIDIA/skills/tree/main/skills/TensorRT-LLM/perf-host-optimization)** - Profiles and optimizes TensorRT-LLM host/CPU overhead using line_profiler (with nsys support planned).
+- **[NVIDIA/TensorRT-LLM/perf-nsight-compute-analysis](https://github.com/NVIDIA/skills/tree/main/skills/TensorRT-LLM/perf-nsight-compute-analysis)** - > Analyze ncu (NVIDIA Nsight Compute) profiling output: SOL% bottleneck classification, roofline analysis, occupancy diagnosis, memory hierarchy analysis, warp stall analysis, metr...
+- **[NVIDIA/TensorRT-LLM/perf-nsight-systems](https://github.com/NVIDIA/skills/tree/main/skills/TensorRT-LLM/perf-nsight-systems)** - >- Nsight Systems (nsys) CLI for system-level timeline profiling.
+- **[NVIDIA/TensorRT-LLM/perf-optimization](https://github.com/NVIDIA/skills/tree/main/skills/TensorRT-LLM/perf-optimization)** - > Performance optimization coordination playbook.
+- **[NVIDIA/TensorRT-LLM/perf-torch-cuda-graphs](https://github.com/NVIDIA/skills/tree/main/skills/TensorRT-LLM/perf-torch-cuda-graphs)** - >- Apply CUDA Graphs to PyTorch workloads — API selection (torch.compile, PyTorch make_graphed_callables, TE make_graphed_callables, MCore CudaGraphManager, FullCudaGraphWrapper, m...
+- **[NVIDIA/TensorRT-LLM/perf-torch-sync-free](https://github.com/NVIDIA/skills/tree/main/skills/TensorRT-LLM/perf-torch-sync-free)** - >- Identify and eliminate host-device synchronizations in PyTorch code.
+- **[NVIDIA/TensorRT-LLM/perf-workload-profiling](https://github.com/NVIDIA/skills/tree/main/skills/TensorRT-LLM/perf-workload-profiling)** - > Code instrumentation for timing workloads.
+- **[NVIDIA/TensorRT-LLM/trtllm-code-contribution](https://github.com/NVIDIA/skills/tree/main/skills/TensorRT-LLM/trtllm-code-contribution)** - > Best practices for contributing code to TensorRT-LLM.
+- **[NVIDIA/TensorRT-LLM/trtllm-codebase-exploration](https://github.com/NVIDIA/skills/tree/main/skills/TensorRT-LLM/trtllm-codebase-exploration)** - > Systematic approach to exploring the TensorRT-LLM codebase before implementing new features or optimizations.
+- **[NVIDIA/TensorRT-LLM/trtllm-flashinfer-upgrade](https://github.com/NVIDIA/skills/tree/main/skills/TensorRT-LLM/trtllm-flashinfer-upgrade)** - >- Upgrade flashinfer-python version in TensorRT-LLM.
+- **[NVIDIA/TensorRT-LLM/trtllm-moe-develop](https://github.com/NVIDIA/skills/tree/main/skills/TensorRT-LLM/trtllm-moe-develop)** - >- Review, design, and refactor TensorRT-LLM PyTorch MoE code for architecture fit, clean code, maintainability, and testability.
+- **[NVIDIA/TensorRT-LLM/trtllm-serve-config-guide](https://github.com/NVIDIA/skills/tree/main/skills/TensorRT-LLM/trtllm-serve-config-guide)** - Generate a source-backed starting `trtllm-serve --config` YAML for basic aggregate single-node PyTorch serving, aligned with checked-in TensorRT-LLM configs and deployment docs.
+
+### TileGym
+
+- **[NVIDIA/TileGym/adding-cutile-kernel](https://github.com/NVIDIA/skills/tree/main/skills/TileGym/adding-cutile-kernel)** - Add a new cuTile GPU kernel operator to TileGym.
+- **[NVIDIA/TileGym/converting-cutile-to-julia](https://github.com/NVIDIA/skills/tree/main/skills/TileGym/converting-cutile-to-julia)** - Converts cuTile Python GPU kernels (@ct.kernel) to cuTile.jl Julia equivalents.
+- **[NVIDIA/TileGym/converting-cutile-to-triton](https://github.com/NVIDIA/skills/tree/main/skills/TileGym/converting-cutile-to-triton)** - Converts cuTile GPU kernels (@ct.kernel) to Triton (@triton.jit).
+- **[NVIDIA/TileGym/cutile-autotuning](https://github.com/NVIDIA/skills/tree/main/skills/TileGym/cutile-autotuning)** - Use when adding, modifying, optimizing, or debugging CuTile autotuning code.
+- **[NVIDIA/TileGym/cutile-python](https://github.com/NVIDIA/skills/tree/main/skills/TileGym/cutile-python)** - Expert cuTile programming assistant.
+- **[NVIDIA/TileGym/improve-cutile-kernel-perf](https://github.com/NVIDIA/skills/tree/main/skills/TileGym/improve-cutile-kernel-perf)** - Iteratively optimize cuTile kernel performance through systematic profiling, bottleneck analysis, IR comparison, and targeted tuning.
+- **[NVIDIA/TileGym/monkey-patch-kernels-to-transformers](https://github.com/NVIDIA/skills/tree/main/skills/TileGym/monkey-patch-kernels-to-transformers)** - Integrate TileGym kernels into Hugging Face `transformers` models by replacing the library's submodule(s) and certain class(es)' implementations, and patching certain class(es)' in...
+
+### cuopt
+
+- **[NVIDIA/cuopt/cuopt-developer](https://github.com/NVIDIA/skills/tree/main/skills/cuopt/cuopt-developer)** - Modify, build, test, debug, and contribute to NVIDIA cuOpt (C++/CUDA, Python, server, CI).
+- **[NVIDIA/cuopt/cuopt-install](https://github.com/NVIDIA/skills/tree/main/skills/cuopt/cuopt-install)** - Install cuOpt for Python, C, or as a server (pip, conda, Docker) — system requirements, install commands, and verification.
+- **[NVIDIA/cuopt/cuopt-numerical-optimization-api-c](https://github.com/NVIDIA/skills/tree/main/skills/cuopt/cuopt-numerical-optimization-api-c)** - LP, MILP, and QP (beta) with cuOpt — C API only.
+- **[NVIDIA/cuopt/cuopt-numerical-optimization-api-cli](https://github.com/NVIDIA/skills/tree/main/skills/cuopt/cuopt-numerical-optimization-api-cli)** - LP, MILP, and QP (beta) with cuOpt — CLI only (MPS files, cuopt_cli).
+- **[NVIDIA/cuopt/cuopt-numerical-optimization-api-python](https://github.com/NVIDIA/skills/tree/main/skills/cuopt/cuopt-numerical-optimization-api-python)** - Solve Linear Programming (LP), Mixed-Integer Linear Programming (MILP), and Quadratic Programming (QP, beta) with the Python API.
+- **[NVIDIA/cuopt/cuopt-routing-api-python](https://github.com/NVIDIA/skills/tree/main/skills/cuopt/cuopt-routing-api-python)** - Vehicle routing (VRP, TSP, PDP) with cuOpt — Python API only.
+- **[NVIDIA/cuopt/cuopt-server-api-python](https://github.com/NVIDIA/skills/tree/main/skills/cuopt/cuopt-server-api-python)** - cuOpt REST server — start server, endpoints, Python/curl client examples.
+- **[NVIDIA/cuopt/cuopt-server-common](https://github.com/NVIDIA/skills/tree/main/skills/cuopt/cuopt-server-common)** - cuOpt REST server — what it does and how requests flow.
+- **[NVIDIA/cuopt/cuopt-user-rules](https://github.com/NVIDIA/skills/tree/main/skills/cuopt/cuopt-user-rules)** - Base rules for end users calling NVIDIA cuOpt (routing/LP/MILP/QP/install/server).
+- **[NVIDIA/cuopt/numerical-optimization-formulation](https://github.com/NVIDIA/skills/tree/main/skills/cuopt/numerical-optimization-formulation)** - Numerical optimization (LP, MILP, QP) — concepts, problem-text parsing, and formulation patterns.
+- **[NVIDIA/cuopt/routing-formulation](https://github.com/NVIDIA/skills/tree/main/skills/cuopt/routing-formulation)** - Vehicle routing (VRP, TSP, PDP) — problem types and data requirements.
+- **[NVIDIA/cuopt/skill-evolution](https://github.com/NVIDIA/skills/tree/main/skills/cuopt/skill-evolution)** - After solving a non-trivial problem, detect generalizable learnings and propose skill updates so future interactions benefit automatically.
+
+### deepstream
+
+- **[NVIDIA/deepstream/deepstream-dev](https://github.com/NVIDIA/skills/tree/main/skills/deepstream/deepstream-dev)** - NVIDIA DeepStream SDK 9.0 development with Python pyservicemaker API.
+- **[NVIDIA/deepstream/deepstream-import-vision-model](https://github.com/NVIDIA/skills/tree/main/skills/deepstream/deepstream-import-vision-model)** - > Use this skill to bring any vision model from HuggingFace or NVIDIA NGC into an NVIDIA DeepStream pipeline with end-to-end automation: ONNX download, SafeTensors export, TRT engi...
+
+### nemotron-voice-agent
+
+- **[NVIDIA/nemotron-voice-agent/nemotron-voice-agent-deploy](https://github.com/NVIDIA/skills/tree/main/skills/nemotron-voice-agent/nemotron-voice-agent-deploy)** - Deploy Nemotron Voice Agent on Workstation (x86), Jetson Thor, or Cloud NIMs.
+
+### rag
+
+- **[NVIDIA/rag/rag-blueprint](https://github.com/NVIDIA/skills/tree/main/skills/rag/rag-blueprint)** - "NVIDIA RAG Blueprint — deploy, configure, troubleshoot, and manage.
+
+### video-search-and-summarization
+
+- **[NVIDIA/video-search-and-summarization/alerts](https://github.com/NVIDIA/skills/tree/main/skills/video-search-and-summarization/alerts)** - Manage and monitor VSS alerts after the alerts profile is deployed.
+- **[NVIDIA/video-search-and-summarization/deploy](https://github.com/NVIDIA/skills/tree/main/skills/video-search-and-summarization/deploy)** - Deploy, debug, or tear down any VSS profile using a compose-centric workflow — config (dry-run) with env overrides, review resolved compose, then compose up.
+- **[NVIDIA/video-search-and-summarization/report](https://github.com/NVIDIA/skills/tree/main/skills/video-search-and-summarization/report)** - Produce video analysis reports by discovering the deployed VSS agent, querying POST /generate for a timestamped captioned summary of the clip, then formatting the agent reply as th...
+- **[NVIDIA/video-search-and-summarization/rt-vlm](https://github.com/NVIDIA/skills/tree/main/skills/video-search-and-summarization/rt-vlm)** - > Use this skill when working with the RTVI VLM or RT-VLM microservice API on VSS 3.1.
+- **[NVIDIA/video-search-and-summarization/video-analytics](https://github.com/NVIDIA/skills/tree/main/skills/video-search-and-summarization/video-analytics)** - Query video analytics data and metrics from Elastic search via the VA-MCP server (port 9901).
+- **[NVIDIA/video-search-and-summarization/video-search](https://github.com/NVIDIA/skills/tree/main/skills/video-search-and-summarization/video-search)** - Search video archives using natural language — find events, objects, actions, and people across recorded video using fusion search (Cosmos Embed1 semantic search + CV attribute sea...
+- **[NVIDIA/video-search-and-summarization/video-summarization](https://github.com/NVIDIA/skills/tree/main/skills/video-search-and-summarization/video-summarization)** - Summarize a video by calling the VLM NIM or the Long Video Summarization (LVS) microservice directly.
+- **[NVIDIA/video-search-and-summarization/video-understanding](https://github.com/NVIDIA/skills/tree/main/skills/video-search-and-summarization/video-understanding)** - Call the vss agent to run video understanding on video to answer a text question.
+- **[NVIDIA/video-search-and-summarization/vios](https://github.com/NVIDIA/skills/tree/main/skills/video-search-and-summarization/vios)** - Query VIOS REST APIs: sensor list, recording timelines, video clip extraction, snapshot capture, add/delete sensors and streams
+- **[NVIDIA/video-search-and-summarization/vss-frag](https://github.com/NVIDIA/skills/tree/main/skills/video-search-and-summarization/vss-frag)** - Generate video summary reports using the VSS video_search_frag extension with Long Video Summarization (LVS), Enterprise RAG knowledge retrieval, and human-in-the-loop parameter co...
+
+</details>
+
+
+<details>
+<summary><h3 style="display:inline">Skills by Google Cloud</h3></summary>
+
+Official Google Cloud skills covering Firebase, BigQuery, Cloud Run, GKE, AlloyDB, Cloud SQL, Gemini Enterprise Agent Platform, networking observability, and the Well-Architected Framework. 19 skills.
+
+- **[google/cloud/agent-platform-skill-registry](https://github.com/google/skills/tree/main/skills/cloud/agent-platform-skill-registry)** - Interact with the Gemini Enterprise Agent Platform Skill Registry to create and search for available skills.
+- **[google/cloud/alloydb-basics](https://github.com/google/skills/tree/main/skills/cloud/alloydb-basics)** - Manages clusters, instances, and backups for AlloyDB for PostgreSQL, and integrates with AlloyDB model context protocol (MCP) tools for automated database operations.
+- **[google/cloud/bigquery-basics](https://github.com/google/skills/tree/main/skills/cloud/bigquery-basics)** - Manages datasets, tables, and jobs in BigQuery, and integrates with BigQuery ML and Gemini for advanced data analytics and AI-driven insights.
+- **[google/cloud/cloud-run-basics](https://github.com/google/skills/tree/main/skills/cloud/cloud-run-basics)** - Manages Cloud Run services, jobs, and worker pools.
+- **[google/cloud/cloud-sql-basics](https://github.com/google/skills/tree/main/skills/cloud/cloud-sql-basics)** - This file generates or explains Cloud SQL resources.
+- **[google/cloud/firebase-basics](https://github.com/google/skills/tree/main/skills/cloud/firebase-basics)** - Use this skill whenever you are working on a project that uses Firebase products or services, especially for mobile or web apps.
+- **[google/cloud/gemini-agents-api](https://github.com/google/skills/tree/main/skills/cloud/gemini-agents-api)** - Manages custom Agent resources on Gemini Enterprise Agent Platform.
+- **[google/cloud/gemini-api](https://github.com/google/skills/tree/main/skills/cloud/gemini-api)** - Guides the usage of the Gemini API on Agent Platform with the Google Gen AI SDK.
+- **[google/cloud/gemini-interactions-api](https://github.com/google/skills/tree/main/skills/cloud/gemini-interactions-api)** - Guides the usage of Gemini Interactions API on Gemini Enterprise Agent Platform.
+- **[google/cloud/gke-basics](https://github.com/google/skills/tree/main/skills/cloud/gke-basics)** - Plan, create, and configure production-ready Google Kubernetes Engine (GKE) clusters using the golden path Autopilot configuration.
+- **[google/cloud/google-cloud-networking-observability](https://github.com/google/skills/tree/main/skills/cloud/google-cloud-networking-observability)** - Investigates Google Cloud networking issues by analyzing logs, metrics, and diagnostics.
+- **[google/cloud/google-cloud-recipe-auth](https://github.com/google/skills/tree/main/skills/cloud/google-cloud-recipe-auth)** - Provides expert guidance on authenticating and authorizing to Google Cloud services and APIs, covering human users, service identities, Application Default Credentials (ADC), and b...
+- **[google/cloud/google-cloud-recipe-onboarding](https://github.com/google/skills/tree/main/skills/cloud/google-cloud-recipe-onboarding)** - Guidance for a developer's first steps on Google Cloud, covering account creation, billing setup, project management, and deploying a first resource.
+- **[google/cloud/google-cloud-waf-cost-optimization](https://github.com/google/skills/tree/main/skills/cloud/google-cloud-waf-cost-optimization)** - Generates cost optimization guidance for Google Cloud workloads based on the Google Cloud Well-Architected Framework (WAF).
+- **[google/cloud/google-cloud-waf-operational-excellence](https://github.com/google/skills/tree/main/skills/cloud/google-cloud-waf-operational-excellence)** - Generates operations-focused guidance for Google Cloud workloads based on the design principles and recommendations in the Operational Excellence pillar of the Google Cloud Well-Ar...
+- **[google/cloud/google-cloud-waf-performance-optimization](https://github.com/google/skills/tree/main/skills/cloud/google-cloud-waf-performance-optimization)** - Generates performance-focused guidance for Google Cloud workloads based on the design principles and recommendations in the Performance Optimization pillar of the Google Cloud Well...
+- **[google/cloud/google-cloud-waf-reliability](https://github.com/google/skills/tree/main/skills/cloud/google-cloud-waf-reliability)** - Generates reliability-focused guidance for Google Cloud workloads based on the design principles and recommendations in the Google Cloud Well-Architected Framework.
+- **[google/cloud/google-cloud-waf-security](https://github.com/google/skills/tree/main/skills/cloud/google-cloud-waf-security)** - Generates security-focused guidance for Google Cloud workloads based on the design principles and recommendations in the Google Cloud Well-Architected Framework (WAF).
+- **[google/cloud/google-cloud-waf-sustainability](https://github.com/google/skills/tree/main/skills/cloud/google-cloud-waf-sustainability)** - Generates sustainability-focused guidance for Google Cloud workloads based on the design principles and recommendations in the Google Cloud Well-Architected Framework (WAF).
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Skills by RedHat</h3></summary>
+
+Extend the power of AI across your organization with a curated library of skills, agents, and MCP servers—all backed by your Red Hat subscription. Whether you’re an SRE optimizing workflows in Cursor or an architect building intelligent interfaces, leverage trusted building blocks to deploy and scale agentic automation with confidence.
+
+- **[redhat/cve-skillpack](https://catalog.redhat.com/en/ai/skills/detail/agentic-skill-pack-for-red-hat-customers#agent-and-skills)** - Understand CVEs, check product lifecycle status, gather diagnostics, and file support cases at the right severity — essential Red Hat skills for everyday operations.
+
+- **[redhat/sre-skillpack](https://catalog.redhat.com/en/ai/skills/detail/agentic-skill-pack-for-site-reliability-engineers)** - Discover, remediate, and verify CVEs across your RHEL fleet — orchestrating Red Hat Lightspeed and Ansible Automation Platform through a single workflow.
+
+- **[redhat/openshift-skillpack](https://catalog.redhat.com/en/ai/skills/detail/agentic-skill-pack-for-red-hat-openshift)** - Provision, inventory, and report on OpenShift clusters — spanning Assisted Installer, OCM, ROSA, ARO, and kubeconfig fleets — through a single conversational workflow.
+
+- **[redhat/openshift-virtualization](https://catalog.redhat.com/en/ai/skills/detail/agentic-skill-pack-for-red-hat-openshift-virtualization)** - Manage the full VM lifecycle on OpenShift Virtualization — create, clone, snapshot, restore, rebalance, and report — through a single conversational workflow.
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Skills by Cypress</h3></summary>
+
+Official skills published by Cypress to help create, maintain, understand, and fix your Cypress tests. 3 skills.
+
+- **[cypress-io/cypress-author](https://github.com/cypress-io/ai-toolkit/tree/main/skills/cypress-author)** - Creates, updates, and fixes Cypress E2E and component tests.
+- **[cypress-io/cypress-explain](https://github.com/cypress-io/ai-toolkit/tree/main/skills/cypress-explain)** - Explains Cypress E2E and component tests, and answers questions about Cypress use and behavior. 
+- **[cypress-io/cypress-docs](https://github.com/cypress-io/ai-toolkit/tree/main/skills/cypress-docs)** - Search and extract Cypress information from official documentation.
+
+</details>
+
+
+### Community Skills
+
+- **[brain-marchine/verify-done-skills](https://github.com/brain-marchine/verify-done-skills)** - Agent skill that refuses Done/Fixed until checks PASS (anti Fake Done)
+<details>
+<summary><h3 style="display:inline">Vector Databases</h3></summary>
+
+- **[qdrant/skills](https://github.com/qdrant/skills)** - Agent skills for Qdrant vector search, covering scaling, performance optimization, search quality, monitoring, deployment, model migration, version upgrades, and SDK usage across Python, TypeScript, Rust, Go, .NET, and Java
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Marketing</h3></summary>
+
+- **[BrianRWagner/ai-marketing-skills](https://github.com/BrianRWagner/ai-marketing-skills)** - 17 marketing frameworks for cold outreach, homepage audit, social cards, and more
+- **[AgriciDaniel/claude-seo](https://github.com/AgriciDaniel/claude-seo)** - Universal SEO skill for comprehensive website analysis and optimization
+- **[wshuyi/x-article-publisher-skill](https://github.com/wshuyi/x-article-publisher-skill)** - Publish articles to X/Twitter
+- **[CosmoBlk/email-marketing-bible](https://github.com/CosmoBlk/email-marketing-bible)** - 55K-word email marketing guide as an AI skill
+- **[smixs/creative-director-skill](https://github.com/smixs/creative-director-skill)** - AI creative director with recursive self-assessment: 20+ methodologies (SIT, TRIZ, Bisociation, SCAMPER, Synectics), 3-axis evaluation calibrated against Cannes/D&AD/HumanKind, 5-phase process from brief to presentation
+- **[Xquik-dev/x-twitter-scraper](https://github.com/Xquik-dev/x-twitter-scraper)** - Tweet search, profile tweets, follower export, media, posting, replies, MCP
+- **[Xquik-dev/tweetclaw](https://github.com/Xquik-dev/tweetclaw)** - Post tweets, replies, DMs; search, monitor, run giveaways
+- **[SHADOWPR0/beautiful_prose](https://github.com/SHADOWPR0/beautiful_prose)** - Hard-edged writing style contract for timeless, forceful English prose without AI tics
+- **[blader/humanizer](https://github.com/blader/humanizer)** - Remove signs of AI-generated writing from text, making it sound more natural and human
+- **[MohamedAbdallah-14/unslop](https://github.com/MohamedAbdallah-14/unslop)** - Removes named AI writing tells (tricolons, em-dash pileups, hedging stacks, sycophancy openers, stock vocab like "delve"/"crucial"). Split lint/rewrite modes for auditing your own text without auto-rewriting. Five intensity levels, MIT
+- **[Eronred/aso-skills](https://github.com/Eronred/aso-skills)** - 30+ App Store Optimization skills for keyword research, metadata optimization, competitor analysis, creative optimization, and mobile growth strategies via Appeeky API
+- **[degausai/wonda](https://github.com/degausai/wonda)** - AI content creation: images, video, music, audio, editing, publishing
+- **[gitroomhq/postiz-agent](https://github.com/gitroomhq/postiz-agent)** - Schedule social media posts across 28+ platforms programmatically
+- **[taisly/agent](https://github.com/taisly/agent)** - Codex plugin, Agent Skill, CLI, and MCP server for publishing approved short-form videos to TikTok, Instagram Reels, YouTube Shorts, X, and Facebook through Taisly
+- **[indranilbanerjee/digital-marketing-pro](https://github.com/indranilbanerjee/digital-marketing-pro)** - 150-skill engagement methodology — 12-Part Strategy Flow, 25 specialist agents, EU AI Act Article 50 ready (C2PA signing), 6-platform AEO/GEO incl. Google AI Mode
+- **[infrasity-labs/dev-gtm-claude-skills](https://github.com/infrasity-labs/dev-gtm-claude-skills)**: GTM-focused skill collection for developer go-to-market workflows including launch planning, positioning, and outbound sequences.
+- **[nowork-studio/NotFair](https://github.com/nowork-studio/NotFair)** - SEO, GEO, Google Ads, and Meta Ads skills with live data
+- **[aaron-he-zhu/aaron-marketing-skills](https://github.com/aaron-he-zhu/aaron-marketing-skills)** - 69 marketing skills across SEO/GEO, influencer, paid ads, and email on one shared contract, with 5 benchmark-driven auditor gates (CORE-EEAT, CITE, C³, ROAS, SEND) and keyless data connectors
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Productivity and Collaboration</h3></summary>
+
+- **[PSPDFKit-labs/nutrient-agent-skill](https://github.com/PSPDFKit-labs/nutrient-agent-skill)** - Document processing with Nutrient DWS API: convert (PDF/DOCX/XLSX/PPTX/HTML/images), extract text/tables, OCR (20+ languages), redact PII (pattern + AI), watermark, digital signatures, form filling. [MCP server](https://www.npmjs.com/package/@nutrient-sdk/dws-mcp-server) also available.
+- **[notiondevs/Notion Skills for Claude](https://www.notion.so/notiondevs/Notion-Skills-for-Claude-28da4445d27180c7af1df7d8615723d0)** - Skills for working with Notion
+- **[op7418/NanoBanana-PPT-Skills](https://github.com/op7418/NanoBanana-PPT-Skills)** - AI-powered PPT generation with document analysis and styled images
+- **[zarazhangrui/frontend-slides](https://github.com/zarazhangrui/frontend-slides)** - Generate animation-rich HTML presentations with visual style previews
+- **[gokapso/integrate-whatsapp](https://github.com/gokapso/agent-skills/tree/master/skills/integrate-whatsapp)** - Connect WhatsApp, set up webhooks, and send messages
+- **[gokapso/automate-whatsapp](https://github.com/gokapso/agent-skills/tree/master/skills/automate-whatsapp)** - Build WhatsApp automations with workflows and agents
+- **[gokapso/observe-whatsapp](https://github.com/gokapso/agent-skills/tree/master/skills/observe-whatsapp)** - Debug WhatsApp delivery issues and run health checks
+- **[PleasePrompto/notebooklm-skill](https://github.com/PleasePrompto/notebooklm-skill)** - Interact with NotebookLM for document-based conversations
+- **[obra/superpowers-lab](https://github.com/obra/superpowers-lab)** - Lab environment for Claude superpowers
+- **[obra/brainstorming](https://github.com/obra/superpowers/blob/main/skills/brainstorming/SKILL.md)** - Generate and explore ideas
+- **[obra/writing-plans](https://github.com/obra/superpowers/blob/main/skills/writing-plans/SKILL.md)** - Create strategic documentation
+- **[obra/executing-plans](https://github.com/obra/superpowers/blob/main/skills/executing-plans/SKILL.md)** - Implement and run strategic plans
+- **[obra/dispatching-parallel-agents](https://github.com/obra/superpowers/blob/main/skills/dispatching-parallel-agents/SKILL.md)** - Coordinate multiple simultaneous agents
+- **[obra/sharing-skills](https://github.com/obra/superpowers/blob/main/skills/sharing-skills/SKILL.md)** - Distribute and communicate capabilities
+- **[obra/using-superpowers](https://github.com/obra/superpowers/blob/main/skills/using-superpowers/SKILL.md)** - Leverage core platform capabilities
+- **[op7418/Youtube-clipper-skill](https://github.com/op7418/Youtube-clipper-skill)** - YouTube clip generation and editing with automated workflows
+- **[ognjengt/founder-skills](https://github.com/ognjengt/founder-skills)** - Claude skills for founders with packaged startup workflows
+- **[EveryInc/charlie-cfo-skill](https://github.com/EveryInc/charlie-cfo-skill)** - Bootstrapped CFO financial management inspired by Charlie Munger
+- **[openaccountants/openaccountants](https://github.com/openaccountants/openaccountants)** - 371 tax classification skills across 134 countries
+- **[wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill)** - Manage Linear issues, projects, and teams
+- **[Shpigford/readme](https://github.com/Shpigford/skills/tree/main/readme)** - Generate comprehensive project documentation
+- **[hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill)** - Minimal, low-friction hierarchical memory system with background agents and filesystem-based persistence
+- **[kreuzberg-dev/kreuzberg](https://github.com/kreuzberg-dev/kreuzberg/tree/main/skills/kreuzberg)** - Extract text, tables, and metadata from 62+ document formats
+- **[Paramchoudhary/ResumeSkills](https://github.com/Paramchoudhary/ResumeSkills)** - 20 specialized skills for resume optimization, ATS analysis, interview prep, and career transitions
+- **[RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills)** - Transform docs or codebases into Obsidian StudyVaults with interactive quizzes
+- **[NeoLabHQ/write-concisely](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/docs/skills/write-concisely)** - Applies the famous *The Elements of Style* book principles to make documentation and writing clearer and more professional by eliminating wordiness and improving structure.
+- **[ReScienceLab/opc-skills](https://github.com/ReScienceLab/opc-skills)** - Agent skills for solopreneurs with SEO, geo, and LLM tools
+- **[SeanZoR/claude-speed-reader](https://github.com/SeanZoR/claude-speed-reader)** - Speed read Claude's responses at 600+ WPM using RSVP with Spritz-style ORP highlighting
+- **[Charlie85270/Dorothy](https://github.com/Charlie85270/Dorothy)** - Orchestrate multiple AI CLI agents with automations and MCP servers
+- **[Digidai/product-manager-skills](https://github.com/Digidai/product-manager-skills)** - Senior PM agent with 30+ frameworks and SaaS metrics
+- **[deusyu/translate-book](https://github.com/deusyu/translate-book)** - Translate books (PDF/DOCX/EPUB) via parallel sub-agents with resume
+- **[mvanhorn/last30days-skill](https://github.com/mvanhorn/last30days-skill)** - Research any topic across Reddit, X, YouTube, HN, Polymarket, and the web, ranked by upvotes, likes, and real money instead of editors
+- **[santifer/career-ops](https://github.com/santifer/career-ops)** - 14-skill collection for AI-powered job search: JD evaluation with A-F scoring, ATS-optimized PDF generation, portal scanners (Greenhouse/Ashby/Lever), interview prep with STAR+R, batch processing, and a Go dashboard TUI
+- **[Linked-API/linkedin](https://github.com/Linked-API/linkedin-skills/tree/main/linkedin)** - Fetch LinkedIn profiles, search people and companies, send messages, manage connections, create posts, react, comment, and run custom LinkedIn workflows from Claude Code, Codex, Cursor, and Windsurf.
+- **[pattern-ai-labs/agentcall](https://github.com/pattern-ai-labs/agentcall)** - Let your AI agents join Google Meet, Zoom, Teams calls and collaborate like a real team-mate.
+- **[Sendmux/skills](https://github.com/Sendmux/skills)** - Sendmux email and mailbox workflows for agents
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Development and Testing</h3></summary>
+
+- **[robzolkos/skill-rails-upgrade](https://github.com/robzolkos/skill-rails-upgrade)** - Analyze Rails apps and provide upgrade assessments
+- **[Shpigford/screenshots](https://github.com/Shpigford/skills/tree/main/screenshots)** - Generate marketing screenshots with Playwright
+- **[antonbabenko/terraform-skill](https://github.com/antonbabenko/terraform-skill)** - Terraform and OpenTofu patterns: testing, modules, state, CI/CD.
+- **[zxkane/aws-skills](https://github.com/zxkane/aws-skills)** - AWS development with infrastructure automation and cloud architecture patterns
+- **[Rootly-AI-Labs/rootly-incident-responder](https://github.com/Rootly-AI-Labs/Rootly-MCP-server/blob/main/examples/skills/rootly-incident-responder.md)** - AI-powered incident response with ML similarity matching, solution suggestions, and on-call coordination. Requires [Rootly MCP Server](https://github.com/Rootly-AI-Labs/Rootly-MCP-server)
+- **[conorluddy/ios-simulator-skill](https://github.com/conorluddy/ios-simulator-skill)** - Control iOS Simulator
+- **[ramzesenok/iOS-Accessibility-Audit-Skill](https://github.com/ramzesenok/iOS-Accessibility-Audit-Skill)** - Audit iOS App against Accessibility norms
+- **[truongduy2611/app-store-preflight-skills](https://github.com/truongduy2611/app-store-preflight-skills)** - Scan iOS/macOS projects to catch common mistakes that lead to App Store rejection before submission
+- **[coderabbitai/skills](https://github.com/coderabbitai/skills)** - Code review and PR autofix workflows for coding agents
+- **[sanjay3290/postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres)** - Execute safe read-only SQL queries against PostgreSQL databases
+- **[sanjay3290/deep-research](https://github.com/sanjay3290/ai-skills/tree/main/skills/deep-research)** - Autonomous multi-step research using Gemini Deep Research Agent
+- **[jthack/ffuf-claude-skill](https://github.com/jthack/ffuf_claude_skill)** - Web fuzzing with ffuf
+- **[lackeyjb/playwright-skill](https://github.com/lackeyjb/playwright-skill)** - Browser automation with Playwright
+- **[ibelick/ui-skills](https://github.com/ibelick/ui-skills)** - Opinionated, evolving constraints to guide agents when building interfaces
+- **[muthuishere/hand-drawn-diagrams](https://github.com/muthuishere/hand-drawn-diagrams)** - Generate hand-drawn Excalidraw diagrams from a prompt — animated SVG, hosted edit link, and PNG export. Works with Claude Code, Codex, Gemini CLI, and any agent supporting standard skill paths
+- **[nextlevelbuilder/ui-ux-pro-max-skill](https://github.com/nextlevelbuilder/ui-ux-pro-max-skill)** - UI/UX design patterns and best practices
+- **[ehmo/platform-design-skills](https://github.com/ehmo/platform-design-skills)** - 300+ design rules from Apple HIG, Material Design 3, and WCAG 2.2 for cross-platform apps
+- **[scarletkc/vexor](https://github.com/scarletkc/vexor)** - Vector-powered CLI for semantic file search with a Claude/Codex skill
+- **[obra/test-driven-development](https://github.com/obra/superpowers/blob/main/skills/test-driven-development/SKILL.md)** - Write tests before implementing code
+- **[obra/subagent-driven-development](https://github.com/obra/superpowers/blob/main/skills/subagent-driven-development/SKILL.md)** - Development using multiple sub-agents
+- **[obra/systematic-debugging](https://github.com/obra/superpowers/blob/main/skills/systematic-debugging/SKILL.md)** - Methodical problem-solving in code
+- **[obra/root-cause-tracing](https://github.com/obra/superpowers/blob/main/skills/root-cause-tracing/SKILL.md)** - Investigate and identify fundamental problems
+- **[obra/testing-skills-with-subagents](https://github.com/obra/superpowers/blob/main/skills/testing-skills-with-subagents/SKILL.md)** - Collaborative testing approaches
+- **[obra/testing-anti-patterns](https://github.com/obra/superpowers/blob/main/skills/testing-anti-patterns/SKILL.md)** - Identify ineffective testing practices
+- **[obra/finishing-a-development-branch](https://github.com/obra/superpowers/blob/main/skills/finishing-a-development-branch/SKILL.md)** - Complete Git code branches
+- **[obra/requesting-code-review](https://github.com/obra/superpowers/blob/main/skills/requesting-code-review/SKILL.md)** - Initiate code review processes
+- **[obra/receiving-code-review](https://github.com/obra/superpowers/blob/main/skills/receiving-code-review/SKILL.md)** - Process and incorporate code feedback
+- **[obra/using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/SKILL.md)** - Manage multiple Git working trees
+- **[obra/verification-before-completion](https://github.com/obra/superpowers/blob/main/skills/verification-before-completion/SKILL.md)** - Validate work before finalizing
+- **[obra/condition-based-waiting](https://github.com/obra/superpowers/blob/main/skills/condition-based-waiting/SKILL.md)** - Manage conditional pauses or delays
+- **[obra/commands](https://github.com/obra/superpowers/tree/main/skills/commands)** - Create and manage command structures
+- **[obra/writing-skills](https://github.com/obra/superpowers/blob/main/skills/writing-skills/SKILL.md)** - Develop and document capabilities
+- **[fvadicamo/dev-agent-skills](https://github.com/fvadicamo/dev-agent-skills)** - Git and GitHub workflow skills for commits, PRs, and code reviews
+- **[omkamal/pypict-skill](https://github.com/omkamal/pypict-claude-skill/blob/main/SKILL.md)** - Pairwise test generation
+- **[alinaqi/claude-bootstrap](https://github.com/alinaqi/claude-bootstrap)** - Opinionated project initialization with security-first guardrails, spec-driven atomic todos, LLM testing patterns, and CLI tool orchestration (gh, vercel, supabase)
+- **[ZhangHanDong/makepad-skills](https://github.com/ZhangHanDong/makepad-skills)** - Makepad UI development skills for Rust apps: setup, patterns, shaders, packaging, and troubleshooting.
+- **[massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill)** - Handle long-context tasks (100+ files, 50k+ tokens) through recursive decomposition strategies based on RLM research
+- **[AvdLee/swiftui-expert-skill](https://github.com/AvdLee/SwiftUI-Agent-Skill/tree/main/swiftui-expert-skill)** - Modern SwiftUI best practices and iOS 26+ Liquid Glass adoption
+- **[efremidze/swift-patterns-skill](https://github.com/efremidze/swift-patterns-skill/tree/main/swift-patterns)** - Modern Swift/SwiftUI best practices
+- **[Joannis/claude-skills](https://github.com/Joannis/claude-skills)** - Swift Server development guidance with linting tool for best practices
+- **[rudrankriyam/app-store-connect-cli-skills](https://github.com/rudrankriyam/app-store-connect-cli-skills)** - Automate App Store deployments and management using ASC CLI
+- **[rameerez/claude-code-startup-skills](https://github.com/rameerez/claude-code-startup-skills)** - Skills for building and running software startups, apps, and SaaS
+- **[zscole/model-hierarchy-skill](https://github.com/zscole/model-hierarchy-skill)** - Cost-optimized model routing based on task complexity
+- **[CloudAI-X/threejs-skills](https://github.com/CloudAI-X/threejs-skills)** - Three.js skills for creating 3D elements and interactive experiences
+- **[Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill)** - High-agency frontend skill that gives AI good taste with tunable design variance, motion intensity, and visual density to stop generic UI slop
+- **[testdino-hq/playwright-skill](https://github.com/testdino-hq/playwright-skill)** - 70+ production-tested Playwright automation testing patterns: E2E, POM, CI/CD, migrations, CLI
+- **[NeoLabHQ/code-review](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/code-review)** - Comprehensive PR code review using specialized agents: bug-hunter, security-auditor, code-quality-reviewer, contracts-reviewer, historical-context-reviewer, test-coverage-reviewer
+- **[NeoLabHQ/reflexion](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/reflexion)** - Self-refinement loop that forces the LLM to reflect on previous output and correct itself.
+- **[NeoLabHQ/sdd](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/sdd)** - Spec-driven development workflow that transforms prompts into production-ready implementations through structured planning, architecture design, and LLM-as-a-Judge based quality gates.
+- **[NeoLabHQ/ddd](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/ddd)** - Domain-driven development skills that also include Clean Architecture, SOLID principles, and design patterns.
+- **[NeoLabHQ/sadd](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/sadd)** - Dispatches independent subagents for individual tasks with code review checkpoints between iterations for rapid, controlled development.
+- **[NeoLabHQ/kaizen](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/kaizen)** - Applies continuous improvement methodology with multiple analytical approaches, based on Japanese Kaizen philosophy and Lean methodology.
+- **[hamelsmu/eval-audit](https://github.com/hamelsmu/prompts/tree/main/evals-skills/skills/eval-audit)** - Audit LLM eval pipelines and surface problems
+- **[hamelsmu/error-analysis](https://github.com/hamelsmu/prompts/tree/main/evals-skills/skills/error-analysis)** - Systematically identify failure modes in LLM pipelines
+- **[hamelsmu/generate-synthetic-data](https://github.com/hamelsmu/prompts/tree/main/evals-skills/skills/generate-synthetic-data)** - Create diverse synthetic test inputs for LLM evals
+- **[hamelsmu/write-judge-prompt](https://github.com/hamelsmu/prompts/tree/main/evals-skills/skills/write-judge-prompt)** - Design LLM-as-Judge evaluators for subjective criteria
+- **[hamelsmu/validate-evaluator](https://github.com/hamelsmu/prompts/tree/main/evals-skills/skills/validate-evaluator)** - Calibrate LLM judges against human labels
+- **[hamelsmu/evaluate-rag](https://github.com/hamelsmu/prompts/tree/main/evals-skills/skills/evaluate-rag)** - Evaluate RAG retrieval and generation quality
+- **[uucz/moyu](https://github.com/uucz/moyu)** - Anti-over-engineering skill with 5 variants and 10 platforms
+- **[hamelsmu/build-review-interface](https://github.com/hamelsmu/prompts/tree/main/evals-skills/skills/build-review-interface)** - Build annotation interfaces for reviewing LLM traces
+- **[mattpocock/skills](https://github.com/mattpocock/skills)** - 17 dev workflow skills: PRD writing, TDD, codebase architecture, git guardrails, issue triage, refactoring plans, and more
+- **[mukul975/Anthropic-Cybersecurity-Skills](https://github.com/mukul975/Anthropic-Cybersecurity-Skills)** - 753 cybersecurity skills across 38 domains: cloud security, pentesting, red teaming, DFIR, malware analysis, threat intel, and more (MITRE ATT&CK mapped)
+- **[wrsmith108/varlock-claude-skill](https://github.com/wrsmith108/varlock-claude-skill)** - Secure environment variable management ensuring secrets are never exposed in Claude sessions, terminals, logs, or git commits
+- **[Skill_Seekers](https://github.com/yusufkaraaslan/Skill_Seekers)** - Automatically convert documentation websites, GitHub repositories, and PDFs into Claude AI skills in minutes
+- **[NoizAI/skills](https://github.com/NoizAI/skills)** - Human-like TTS workflows with local/cloud APIs and app delivery
+- **[Kevin7Qi/codex-collab](https://github.com/Kevin7Qi/codex-collab)** - Collaborate with Codex from Claude Code
+- **[ethos-link/rails-conventions](https://github.com/ethos-link/rails-conventions)** - Rails 8 conventions for consistent production code changes
+- **[ShunsukeHayashi/agent-skill-bus](https://github.com/ShunsukeHayashi/agent-skill-bus)** - Self-improving task orchestration for AI agent systems
+- **[mcollina/skills](https://github.com/mcollina/skills/tree/main/skills)** - 11 skills by Matteo Collina: Node.js, Fastify, TypeScript, OAuth, Git/GitHub, ESLint neostandard, documentation (Diataxis), Node.js core internals, skill optimizer, and more
+- **[Lum1104/understand-anything](https://github.com/Lum1104/Understand-Anything)** - Interactive codebase knowledge graphs via multi-agent LLM analysis
+- **[hqhq1025/skill-optimizer](https://github.com/hqhq1025/skill-optimizer)** - Diagnose and optimize Agent Skills (SKILL.md) with real session data and research-backed static analysis. Works with Claude Code, Codex, and any Agent Skills-compatible agent
+- **[LambdaTest/agent-skills](https://github.com/LambdaTest/agent-skills)** - TestMu AI (Formerly LambdaTest) Skills is a curated collection of Agent Skills that teach AI coding assistants how to write production-grade test automation.
+- **[foryourhealth111-pixel/Vibe-Skills](https://github.com/foryourhealth111-pixel/Vibe-Skills)** - A skills governed plug-and-play harness for staged, test-driven skill orchestration
+- **[metalbear-co/skills](https://github.com/metalbear-co/skills)** - Skills that let agents code and test against your Kubernetes cluster using mirrord
+- **[dembrandt/dembrandt-skills](https://github.com/dembrandt/dembrandt-skills)** - UX and design system skills: hierarchy, typography, accessibility, interactions
+- **[GanyuanRan/Aegis](https://github.com/GanyuanRan/Aegis)** - Evidence-driven method pack for AI coding agents
+- **[baskduf/codex-fable5](https://github.com/baskduf/FableCodex/tree/main/plugins/codex-fable5/skills/codex-fable5)** - Evidence-based workflow gates for Codex
+- **[csthink/dashmotion](https://github.com/csthink/dashmotion/tree/main/skills/dashmotion)** - Animated technical diagrams from plain English or Mermaid, self-contained HTML/SVG
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Context Engineering</h3></summary>
+
+- **[muratcankoylan/context-fundamentals](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/context-fundamentals)** - Understand what context is, why it matters, and the anatomy of context in agent systems
+- **[muratcankoylan/context-degradation](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/context-degradation)** - Recognize patterns of context failure: lost-in-middle, poisoning, distraction, and clash
+- **[muratcankoylan/context-compression](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/context-compression)** - Design and evaluate compression strategies for long-running sessions
+- **[muratcankoylan/context-optimization](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/context-optimization)** - Apply compaction, masking, and caching strategies
+- **[muratcankoylan/multi-agent-patterns](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/multi-agent-patterns)** - Master orchestrator, peer-to-peer, and hierarchical multi-agent architectures
+- **[muratcankoylan/memory-systems](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/memory-systems)** - Design short-term, long-term, and graph-based memory architectures
+- **[muratcankoylan/tool-design](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/tool-design)** - Build tools that agents can use effectively, including architectural reduction patterns
+- **[muratcankoylan/evaluation](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/evaluation)** - Build evaluation frameworks for agent systems
+- **[k-kolomeitsev/data-structure-protocol](https://github.com/k-kolomeitsev/data-structure-protocol)** - Graph-based long-term memory skill for AI (LLM) coding agents — faster context, fewer tokens, safer refactors
+- **[awrshift/claude-memory-kit](https://github.com/awrshift/claude-memory-kit)** - Persistent memory with hooks, wiki, and daily synthesis for multi-project workflows
+- **[NeoLabHQ/prompt-engineering](https://github.com/NeoLabHQ/context-engineering-kit/tree/master/plugins/customaize-agent/skills/prompt-engineering)** - Widely used prompt engineering techniques and patterns, including Anthropic best practices and agent persuasion principles.
+- **[sametbrr/llm-wiki-manager](https://github.com/sametbrr/llm-wiki-manager)** - Persistent LLM-managed personal wiki — the model writes, cross-references, and maintains the knowledge base while you curate sources. Implements Karpathy's LLM Wiki pattern with 8 operating modes.
+- **[Panniantong/Agent-Reach](https://github.com/Panniantong/Agent-Reach)** - Multi-platform search CLI for 17 sites including Chinese platforms
+- **[Tubo2333/obsidian-knowledge-brain](https://github.com/Tubo2333/obsidian-knowledge-brain)** - Cross-session knowledge memory and rule evolution for AI coding agents
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">Specialized Domains</h3></summary>
+
+- **[shouldnotappearcalm/a-share-skill](https://github.com/shouldnotappearcalm/a-share-skill)** - China A-share (Shanghai/Shenzhen) skills: real-time quotes, K-line history, technical indicators, events, capital flows, sector heatmaps, and paper trading. Works with Claude Code, Cursor, Codex, and Qoder
+- **[transloadit/skills](https://github.com/transloadit/skills/tree/main/skills)** - Transloadit skill collection (6)
+- **[honeydew-ai/honeydew-ai-coding-agents-plugins](https://github.com/honeydew-ai/honeydew-ai-coding-agents-plugins)** - 11 skills for the Honeydew semantic layer over Snowflake, Databricks, and BigQuery: model exploration, entity/relation/attribute/metric/context/domain creation, validation, query, filtering, and workspace branching
+- **[raintree-technology/apple-hig-skills](https://github.com/raintree-technology/apple-hig-skills)** - Apple Human Interface Guidelines as 14 agent skills covering platforms, foundations, components, patterns, inputs, and technologies for iOS, macOS, visionOS, watchOS, and tvOS
+- **[K-Dense-AI/claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills)** - Scientific research and analysis skills
+- **[NotMyself/claude-win11-speckit-update-skill](https://github.com/NotMyself/claude-win11-speckit-update-skill)** - Windows 11 system management
+- **[sanjay3290/imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen)** - Generate images using Google Gemini's API
+- **[jeffersonwarrior/claudisms](https://github.com/jeffersonwarrior/claudisms)** - SMS messaging integration
+- **[SHADOWPR0/security-bluebook-builder](https://github.com/SHADOWPR0/security-bluebook-builder)** - Build security Blue Books for sensitive apps
+- **[obra/defense-in-depth](https://github.com/obra/superpowers/blob/main/skills/defense-in-depth/SKILL.md)** - Multi-layered security approaches
+- **[huifer/Claude-Ally-Health](https://github.com/huifer/Claude-Ally-Health)** - A health assistant skill for medical information analysis, symptom tracking, and wellness guidance.
+- **[frmoretto/clarity-gate](https://github.com/frmoretto/clarity-gate)** - Epistemic quality verification for RAG systems
+- **[wanshuiyin/Auto-claude-code-research-in-sleep](https://github.com/wanshuiyin/Auto-claude-code-research-in-sleep)** - Autonomous ML research with cross-model review loops and GPU deployment
+- **[zechenzhangAGI/AI-research-SKILLs](https://github.com/zechenzhangAGI/AI-research-SKILLs)** - 77 AI research skills for model training, inference, and MLOps
+- **[Orchestra-Research/AI-research-SKILLs](https://github.com/Orchestra-Research/AI-research-SKILLs)** - 20-module AI research skill library for model architecture, training, and ML paper writing
+- **[komal-SkyNET/claude-skill-homeassistant](https://github.com/komal-SkyNET/claude-skill-homeassistant)** - Supercharge and manage Home Assistant workflows
+- **[more-io/apple-bridges](https://github.com/more-io/claude-apple-bridges)** - Native macOS app access — manage Apple Reminders, Calendar, Contacts, Notes, Mail, and tmux sessions via Swift CLI bridges
+- **[hanhuark/mechanical-engineering-research-skill](https://github.com/hanhuark/mechanical-engineering-research-skill)** - Thermal-fluid research writing, proposals, DOE, and presentation feedback
+- **[prompt-security/clawsec](https://github.com/prompt-security/clawsec)** - Security skill suite with drift detection, automated audits, and skill integrity verification
+- **[BehiSecc/vibesec](https://github.com/BehiSecc/VibeSec-Skill)** - Helps write secure code by preventing common vulnerabilities including IDOR, XSS, SQL injection, SSRF, and weak authentication, approaching code from a bug hunter's perspective
+- **[lawvable/awesome-legal-skills](https://github.com/lawvable/awesome-legal-skills)** - Curated agent skills for automating legal workflows
+- **[peas/genealogy-research](https://paulo.com.br/skills/genealogy-research/SKILL.md)** - Genealogy research agent with OCR, FamilySearch, YAML data, and human-in-the-loop
+- **[zw008/VMware-AIops](https://github.com/zw008/VMware-AIops)** - AI-powered VMware vCenter/ESXi monitoring and operations: inventory queries, health/alarms, VM lifecycle (create, delete, snapshot, clone, migrate), vSAN management, Aria Operations analytics, and scheduled log scanning. Supports Claude Code, Gemini CLI, Codex, Aider, Trae, Kimi, and MCP.
+- **[video-db/skills](https://github.com/video-db/skills)** - Realtime and batch video workflows: capture screen/audio, ingest URLs/YouTube/RTSP, transcribe, index, search, generate subtitles, edit timelines, and stream HLS output
+- **[materials-simulation-skills](https://github.com/HeshamFS/materials-simulation-skills)** - Agent skills for computational materials science: numerical stability, time-stepping, linear solvers, mesh generation, simulation validation, parameter optimization, and post-processing
+- **[Ericyoung-183/alpha-insights](https://github.com/Ericyoung-183/alpha-insights)** - Harness-enforced business research for Claude Code and Codex
+- **[takechanman1228/claude-ecom](https://github.com/takechanman1228/claude-ecom)** - Ecommerce CSV to business review with KPI decomposition
+- **[talkstream/ru-text](https://github.com/talkstream/ru-text)** - Russian text quality: ~1,040 rules for typography, info-style, editorial, UX writing, business correspondence. Cross-platform: Claude Code, Codex CLI, Gemini CLI, Cursor.
+- **[helius-labs/helius-skills](https://github.com/helius-labs/core-ai/tree/main/helius-skills)** - Ship Solana apps end-to-end; transaction sending, asset queries, real-time streaming, token swaps, prediction markets, browser wallets, and deep research into protocol internals all powered by Helius APIs, DFlow trading, and Phantom wallet integrations
+- **[meodai/skill.color-expert](https://github.com/meodai/skill.color-expert)** - Color science expert skill with 286K words of reference material covering OKLCH/OKLAB, palette generation, accessibility/contrast, color naming, pigment mixing, and historical color theory
+- **[aklofas/kicad-happy](https://github.com/aklofas/kicad-happy)** - AI-powered KiCad electronics design review and analysis
+- **[bitwize-music-studio/claude-ai-music-skills](https://github.com/bitwize-music-studio/claude-ai-music-skills)** - Full-lifecycle AI music album production
+- **[Alisa0808/vibe-creating-skill](https://github.com/Alisa0808/vibe-creating-skill)** - Rewrites a rough idea or shot script into text-to-video prompts
+
+</details>
+
+<details>
+<summary><h3 style="display:inline">n8n Automation</h3></summary>
+
+- **[czlonkowski/n8n-code-javascript](https://github.com/czlonkowski/n8n-skills/tree/main/skills/n8n-code-javascript)** - JavaScript in n8n Code nodes with data access patterns
+- **[czlonkowski/n8n-code-python](https://github.com/czlonkowski/n8n-skills/tree/main/skills/n8n-code-python)** - Python coding in n8n Code nodes with limitations
+- **[czlonkowski/n8n-expression-syntax](https://github.com/czlonkowski/n8n-skills/tree/main/skills/n8n-expression-syntax)** - n8n expression syntax with {{}} and $json/$node variables
+- **[czlonkowski/n8n-mcp-tools-expert](https://github.com/czlonkowski/n8n-skills/tree/main/skills/n8n-mcp-tools-expert)** - MCP tools guide with tool selection and node formats
+- **[czlonkowski/n8n-node-configuration](https://github.com/czlonkowski/n8n-skills/tree/main/skills/n8n-node-configuration)** - Node configuration with dependency rules and AI connections
+- **[czlonkowski/n8n-validation-expert](https://github.com/czlonkowski/n8n-skills/tree/main/skills/n8n-validation-expert)** - Fix n8n validation errors with error catalog
+- **[czlonkowski/n8n-workflow-patterns](https://github.com/czlonkowski/n8n-skills/tree/main/skills/n8n-workflow-patterns)** - Workflow patterns for webhook, HTTP, database, and AI tasks
+
+</details>
+
+
+
+
+## 🔒 Security Notice
+
+Skills in this list are curated, not audited. They may be updated, modified, or replaced by their original maintainers at any time after being added here.
+
+Before installing or using any Agent Skill, review potential security risks and validate the source yourself.
+
+Recommended tools:
+
+- [Synk Skill Security Scanner](https://github.com/snyk/agent-scan)
+- [Agent Trust Hub](https://ai.gendigital.com/agent-trust-hub)
+
+Agent skills can include prompt injections, tool poisoning, hidden malware payloads, or unsafe data handling patterns. Always review the code and use skills at your own discretion.
+
+
+## Skills Paths for Other AI Coding Assistants
+
+| Tool | Project Path | Global Path | Official Docs |
+|------|-------------|-------------|---------------|
+| Antigravity | `.agent/skills/` | `~/.gemini/antigravity/skills/` | [Antigravity Skills](https://antigravity.google/docs/skills) |
+| Claude Code | `.claude/skills/` | `~/.claude/skills/` | [Claude Code Skills](https://docs.anthropic.com/en/docs/claude-code/skills) |
+| Codex | `.agents/skills/` | `~/.agents/skills/` | [Codex Skills](https://developers.openai.com/codex/skills) |
+| Cursor | `.cursor/skills/` | `~/.cursor/skills/` | [Cursor Skills](https://cursor.com/docs/context/skills) |
+| Gemini CLI | `.gemini/skills/` | `~/.gemini/skills/` | [Gemini CLI Skills](https://geminicli.com/docs/cli/skills/) |
+| GitHub Copilot | `.github/skills/` | `~/.copilot/skills/` | [Copilot Skills](https://docs.github.com/en/copilot/concepts/agents/about-agent-skills) |
+| OpenCode | `.opencode/skills/` | `~/.config/opencode/skills/` | [OpenCode Skills](https://opencode.ai/docs/skills) |
+| Windsurf | `.windsurf/skills/` | `~/.codeium/windsurf/skills/` | [Windsurf Cascade Skills](https://docs.windsurf.com/windsurf/cascade/skills) |
+
+
+## Skill Quality Standards
+
+As the ecosystem grows, consistent quality helps agents discover and use skills reliably. The following references and criteria keep the bar high.
+
+
+### Quality Criteria
+
+| Area | Guideline |
+|------|-----------|
+| **Description** | Write in third person. State *what* the skill does and *when* to use it. Use specific keywords agents can match on (e.g., "PostgreSQL migration" not "database stuff"). |
+| **Progressive disclosure** | Keep top-level metadata under ~100 tokens. Skill body should stay below 500 lines. Load resources (large docs, schemas) on demand, not inline. |
+| **No absolute paths** | Never hard-code machine-specific paths like `/Users/alice/`. Use relative paths or well-known variables (`$HOME`, `$PROJECT_ROOT`). |
+| **Scoped tools** | Request only the tools the skill actually needs. Avoid blanket `"tools": ["*"]`. Declare tool dependencies explicitly. |
+
+
+## 🤝 Contributing
+
+We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+
+- Submit new skills via PR
+- Improve existing definitions
+
+**Note:** Please don't submit skills you created 3 hours ago. We're now focusing on community-adopted skills, especially those published by development teams and proven in real-world usage. Quality over quantity.
+
+## Contributor ♥️ Thanks
+![Contributors](https://contrib.rocks/image?repo=voltagent/awesome-agent-skills&max=500&columns=20&anon=1)
 
 ## License
 
-[![CC0](https://licensebuttons.net/p/zero/1.0/88x31.png)](https://creativecommons.org/publicdomain/zero/1.0/)
+MIT License - see [LICENSE](LICENSE)
 
-To the extent possible under law, the contributors have waived all copyright and related rights to this work.
+This is a curated list. Skills listed here are created and maintained by their respective authors and teams, not by us. We select community-adopted, proven skills and do not audit, endorse, or guarantee the security or correctness of listed projects. They are not security-audited and should be reviewed before production use.
+
+If you find an issue with a listed skill or want your skill removed, please [open an issue](https://github.com/VoltAgent/awesome-agent-skills/issues) and we'll take care of it promptly.
+
+[codex-badge]: https://img.shields.io/github/stars/VoltAgent/awesome-codex-subagents?style=classic&label=Codex%20Subagents&color=000000&logo=data:image/svg%2bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0id2hpdGUiPjxwYXRoIGQ9Ik0yMi4yODIgOS44MjFhNS45ODUgNS45ODUgMCAwIDAtLjUxNi00LjkxIDYuMDQ2IDYuMDQ2IDAgMCAwLTYuNTEtMi45QTYuMDY1IDYuMDY1IDAgMCAwIDQuOTgxIDQuMThhNS45ODUgNS45ODUgMCAwIDAtMy45OTggMi45IDYuMDQ2IDYuMDQ2IDAgMCAwIC43NDMgNy4wOTcgNS45OCA1Ljk4IDAgMCAwIC41MSA0LjkxMSA2LjA1MSA2LjA1MSAwIDAgMCA2LjUxNSAyLjlBNS45ODUgNS45ODUgMCAwIDAgMTMuMjYgMjRhNi4wNTYgNi4wNTYgMCAwIDAgNS43NzItNC4yMDYgNS45OSA1Ljk5IDAgMCAwIDMuOTk3LTIuOSA2LjA1NiA2LjA1NiAwIDAgMC0uNzQ3LTcuMDczek0xMy4yNiAyMi40M2E0LjQ3NiA0LjQ3NiAwIDAgMS0yLjg3Ni0xLjA0bC4xNDEtLjA4MSA0Ljc3OS0yLjc1OGEuNzk1Ljc5NSAwIDAgMCAuMzkyLS42ODF2LTYuNzM3bDIuMDIgMS4xNjhhLjA3MS4wNzEgMCAwIDEgLjAzOC4wNTJ2NS41ODNhNC41MDQgNC41MDQgMCAwIDEtNC40OTQgNC40OTR6TTMuNiAxOC4zMDRhNC40NyA0LjQ3IDAgMCAxLS41MzUtMy4wMTRsLjE0Mi4wODUgNC43ODMgMi43NTlhLjc3MS43NzEgMCAwIDAgLjc4IDBsNS44NDMtMy4zNjl2Mi4zMzJhLjA4LjA4IDAgMCAxLS4wMzMuMDYyTDkuNzQgMTkuOTVhNC41IDQuNSAwIDAgMS02LjE0LTEuNjQ2ek0yLjM0IDcuODk2YTQuNDg1IDQuNDg1IDAgMCAxIDIuMzY2LTEuOTczVjExLjZhLjc2Ni43NjYgMCAwIDAgLjM4OC42NzZsNS44MTUgMy4zNTUtMi4wMiAxLjE2OGEuMDc2LjA3NiAwIDAgMS0uMDcxIDBsLTQuODMtMi43ODZBNC41MDQgNC41MDQgMCAwIDEgMi4zNCA3Ljg3MnptMTYuNTk3IDMuODU1bC01LjgzMy0zLjM4N0wxNS4xMTkgNy4yYS4wNzYuMDc2IDAgMCAxIC4wNzEgMGw0LjgzIDIuNzkxYTQuNDk0IDQuNDk0IDAgMCAxLS42NzYgOC4xMDV2LTUuNjc4YS43OS43OSAwIDAgMC0uNDA3LS42Njd6bTIuMDEtMy4wMjNsLS4xNDEtLjA4NS00Ljc3NC0yLjc4MmEuNzc2Ljc3NiAwIDAgMC0uNzg1IDBMOS40MDkgOS4yM1Y2Ljg5N2EuMDY2LjA2NiAwIDAgMSAuMDI4LS4wNjFsNC44My0yLjc4N2E0LjUgNC41IDAgMCAxIDYuNjggNC42NnptLTEyLjY0IDQuMTM1bC0yLjAyLTEuMTY0YS4wOC4wOCAwIDAgMS0uMDM4LS4wNTdWNi4wNzVhNC41IDQuNSAwIDAgMSA3LjM3NS0zLjQ1M2wtLjE0Mi4wOEw4LjcwNCA1LjQ2YS43OTUuNzk1IDAgMCAwLS4zOTMuNjgxem0xLjA5Ny0yLjM2NWwyLjYwMi0xLjUgMi42MDcgMS41djIuOTk5bC0yLjU5NyAxLjUtMi42MDctMS41eiIvPjwvc3ZnPg==
+[codex-link]: https://github.com/VoltAgent/awesome-codex-subagents


### PR DESCRIPTION
## Summary
Adds [verify-done-skills](https://github.com/brain-marchine/verify-done-skills): an Agent Skill that blocks verbal Done/Fixed until independent checks (git diff / vacuous tests / npm test / optional URL probe) PASS.

## Install
```
npx skills add brain-marchine/verify-done-skills
```

## Why
Addresses Fake Done - agents claiming Fixed while the product is still wrong. Skill-first install for Cursor / Claude Code.