### PR TITLE
Add Markstream Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The [Agent Skills spec](https://github.com/anthropics/skills) is the emerging cr
 ### Domain-Specific
 
 - [K-Dense-AI/claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills) - Ready-to-use skills for research, science, engineering, analysis, finance and writing. ![GitHub stars](https://img.shields.io/github/stars/K-Dense-AI/claude-scientific-skills)
+- [Markstream Agent Skills](https://github.com/Simon-He95/markstream-vue/tree/main/.agents/skills) - Official skills for streaming Markdown across Vue, React, Svelte, Angular, Nuxt, Next.js, and Vue 2. ![GitHub stars](https://img.shields.io/github/stars/Simon-He95/markstream-vue)
 
 ### Collections
 


### PR DESCRIPTION
## Summary

Adds the official Markstream Agent Skills collection to the Domain-Specific section.

Markstream provides 11 reusable `SKILL.md` workflows for installing, configuring, customizing, and migrating streaming Markdown renderers across Vue, React, Svelte, Angular, Nuxt, Next.js, and Vue 2.

## Checks

- Confirmed there is no existing Markstream entry in the repository.
- Kept this PR to one entry.
- Description is 100 characters, below the 120-character limit.
- Source link resolves successfully and the project is actively maintained.
- Entry follows the requested format and alphabetical order.
- `git diff --check` passes.

Thank you for maintaining this cross-platform directory.
