### PR TITLE
Add UIZZE anti-ui-slop skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The [Agent Skills spec](https://github.com/anthropics/skills) is the emerging cr
 ### Domain-Specific
 
 - [K-Dense-AI/claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills) - Ready-to-use skills for research, science, engineering, analysis, finance and writing. ![GitHub stars](https://img.shields.io/github/stars/K-Dense-AI/claude-scientific-skills)
-- [UIZZE anti-ui-slop](https://github.com/samuelbushi/uizze/tree/main/skills/anti-ui-slop) - Free UI finish gate grounded in 800,000+ real web and iOS screens at [uizze.com](https://uizze.com). ![GitHub stars](https://img.shields.io/github/stars/samuelbushi/uizze)
+- [UIZZE anti-ui-slop](https://github.com/uizze/uizze/tree/main/skills/anti-ui-slop) - Free UI finish gate grounded in 800,000+ real web and iOS screens at [uizze.com](https://uizze.com). ![GitHub stars](https://img.shields.io/github/stars/uizze/uizze)
 
 ### Collections
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The [Agent Skills spec](https://github.com/anthropics/skills) is the emerging cr
 ### Domain-Specific
 
 - [K-Dense-AI/claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills) - Ready-to-use skills for research, science, engineering, analysis, finance and writing. ![GitHub stars](https://img.shields.io/github/stars/K-Dense-AI/claude-scientific-skills)
+- [UIZZE anti-ui-slop](https://github.com/samuelbushi/uizze/tree/main/skills/anti-ui-slop) - Free UI finish gate grounded in 800,000+ real web and iOS screens at [uizze.com](https://uizze.com). ![GitHub stars](https://img.shields.io/github/stars/samuelbushi/uizze)
 
 ### Collections
 


### PR DESCRIPTION
## What changed

Adds one entry to the Domain-Specific Agent Skills section for the official MIT-licensed UIZZE anti-ui-slop skill.

The linked skill is free to install and use. Its manual workflow requires no account, token, MCP connection, executable, or dependency; it grounds web and iOS interface work in the public UIZZE catalogue and enforces a finish gate before shipping.

## Why it belongs

- Native SKILL.md source compatible with Agent Skills hosts
- Relevant to React, Next.js, web, and iOS interface work
- Official source from the UIZZE publisher
- Canonical skill link plus plain https://uizze.com catalogue link
- One entry, no duplicate, alphabetical placement, and an under-120-character description

## Validation

- Full repository markdown link check passed with the target configuration
- Canonical skill source returned HTTP 200
- https://uizze.com returned HTTP 200
- GitHub stars badge returned HTTP 200
- git diff --check passed
