### PR TITLE
Add JobYap agent skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The [Agent Skills spec](https://github.com/anthropics/skills) is the emerging cr
 
 ### Domain-Specific
 
+- [jobyap/agent-skills](https://github.com/jobyap/agent-skills) - Search job postings from companies' official careers sites — salaries, locations, and community discussion on every job. ![GitHub stars](https://img.shields.io/github/stars/jobyap/agent-skills)
 - [K-Dense-AI/claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills) - Ready-to-use skills for research, science, engineering, analysis, finance and writing. ![GitHub stars](https://img.shields.io/github/stars/K-Dense-AI/claude-scientific-skills)
 
 ### Collections


### PR DESCRIPTION
## Summary
Adds jobyap/agent-skills under Domain-Specific Agent Skills.

## What it is
An Agent Skill (plus Claude Code / Antigravity plugins and a stdio MCP bridge) for searching job postings aggregated from companies' official careers sites — salaries, locations, and community discussion on every job. Works via the public JSON API or remote MCP.

## Links
- Repo: https://github.com/jobyap/agent-skills
- Docs: https://jobyap.com/agents