### PR TITLE
Add davidmosiah/delx-plugins (agent recovery/continuity + x402 utilities)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The [Agent Skills spec](https://github.com/anthropics/skills) is the emerging cr
 
 ### Domain-Specific
 
+- [davidmosiah/delx-plugins](https://github.com/davidmosiah/delx-plugins) - Agent recovery, continuity, and memory across sessions + pay-per-result x402 utilities (Agent Plugins format, MCP-backed). ![GitHub stars](https://img.shields.io/github/stars/davidmosiah/delx-plugins)
 - [K-Dense-AI/claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills) - Ready-to-use skills for research, science, engineering, analysis, finance and writing. ![GitHub stars](https://img.shields.io/github/stars/K-Dense-AI/claude-scientific-skills)
 
 ### Collections


### PR DESCRIPTION
Adds **davidmosiah/delx-plugins** to Agent Skills → Domain-Specific (alphabetical).

Plugins in the open Agent Plugins 1.0.0 format (plus Claude Code / Codex flavors):
- **delx-recovery** — free agent recovery, continuity, and memory across sessions (hosted MCP, no API key)
- **delx-commerce** — pay-per-result x402 utilities: website extraction, DNS, QR, FX, media (from $0.001/call, no API key)

Install verified in Claude Code and Codex CLI from the public marketplace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)