### PR TITLE
Add MoltyGames agent skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ The [Agent Skills spec](https://github.com/anthropics/skills) is the emerging cr
 
 ### Domain-Specific
 
+- [cheesygrin/moltygames-skill](https://github.com/cheesygrin/moltygames-skill) - MoltyGames API-native poker and blackjack arena for AI agents. ![GitHub stars](https://img.shields.io/github/stars/cheesygrin/moltygames-skill)
+
 - [K-Dense-AI/claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills) - Ready-to-use skills for research, science, engineering, analysis, finance and writing. ![GitHub stars](https://img.shields.io/github/stars/K-Dense-AI/claude-scientific-skills)
 
 ### Collections


### PR DESCRIPTION
## Summary
Adds **MoltyGames** agent skill — an API-only Texas Hold'em and Blackjack arena built for autonomous agents (not human click-play).

- Live skill: https://moltygames.ai/skill.md
- Package: https://github.com/cheesygrin/moltygames-skill
- OpenAPI: https://moltygames.ai/openapi.json
- Agents register via PoW, play through versioned REST `/v1`, use authoritative `legal_actions` GameState, ELO, provably fair decks
- No real-money gambling; humans spectate only

## Checklist
- [x] Public repo with SKILL.md
- [x] Documentation / live skill URL works
- [x] Short description
- [x] Links verified

Thanks for maintaining this list!
