### PR TITLE
Add Hexis to Directories and Marketplaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ Web-based platforms for discovering and installing agent skills and tools.
 | [Gemini Extension Gallery](https://geminicli.com/extensions/) | Gemini CLI extensions | Growing | No |
 | [GitHub Copilot Marketplace](https://github.com/marketplace?type=apps&copilot_app=true) | Copilot extensions | ~30 | No |
 | [LobeHub MCP](https://lobehub.com/mcp) | LobeChat MCP marketplace | Growing | Partial |
+| [Hexis](https://github.com/Bevel-Software/Hexis) | Team skill, tool, and context management | Private workspaces | [Yes](https://github.com/Bevel-Software/Hexis) |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Web-based platforms for discovering and installing agent skills and tools.
 | [Gemini Extension Gallery](https://geminicli.com/extensions/) | Gemini CLI extensions | Growing | No |
 | [GitHub Copilot Marketplace](https://github.com/marketplace?type=apps&copilot_app=true) | Copilot extensions | ~30 | No |
 | [LobeHub MCP](https://lobehub.com/mcp) | LobeChat MCP marketplace | Growing | Partial |
-| [Hexis](https://github.com/Bevel-Software/Hexis) | Team skill, tool, and context management | Private workspaces | [Yes](https://github.com/Bevel-Software/Hexis) |
+| [Hexis](https://github.com/Bevel-Software/Hexis) | Git-backed platform for team skills, tools, and context | Private workspaces | [Yes](https://github.com/Bevel-Software/Hexis) |
 
 ---
 


### PR DESCRIPTION
Adds Hexis to Directories and Marketplaces as an open-source platform for private team workspaces. It manages skills, tools, and context for AI agents and meets the 10-star quality threshold.