### PR TITLE
Add Anycloud agent skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The [Agent Skills spec](https://github.com/anthropics/skills) is the emerging cr
 
 ### Domain-Specific
 
+- [anycloud-sh/anycloud-skills](https://github.com/anycloud-sh/anycloud-skills) - Run AI jobs across cloud GPU providers from Claude Code, Codex, and ChatGPT. ![GitHub stars](https://img.shields.io/github/stars/anycloud-sh/anycloud-skills)
 - [K-Dense-AI/claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills) - Ready-to-use skills for research, science, engineering, analysis, finance and writing. ![GitHub stars](https://img.shields.io/github/stars/K-Dense-AI/claude-scientific-skills)
 
 ### Collections


### PR DESCRIPTION
## Summary

Adds the official Anycloud skill to the Domain-Specific section. The repository contains an Agent Skills-compatible `SKILL.md` for running AI workloads across connected cloud GPU providers from Claude Code, Codex, and ChatGPT.

## Validation

- confirmed the source repository and badge URLs resolve
- kept the description under 120 characters
- added one entry in alphabetical order

Disclosure: I maintain Anycloud.