### PR TITLE
Add Odai agent governance skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The [Agent Skills spec](https://github.com/anthropics/skills) is the emerging cr
 ### Domain-Specific
 
 - [K-Dense-AI/claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills) - Ready-to-use skills for research, science, engineering, analysis, finance and writing. ![GitHub stars](https://img.shields.io/github/stars/K-Dense-AI/claude-scientific-skills)
+- [orziz/odai](https://github.com/orziz/odai) - Agent governance for evidence-driven planning, responsibility routing, safety boundaries, and verified delivery. ![GitHub stars](https://img.shields.io/github/stars/orziz/odai)
 
 ### Collections
 


### PR DESCRIPTION
Adds [Odai](https://github.com/orziz/odai) to the Agent Skills section. Odai provides a canonical `SKILL.md` governance entry for evidence-driven planning, responsibility routing, authorization and safety boundaries, and verified delivery. The project is open source, actively maintained, and exceeds the repository quality bar.