### PR TITLE
Add golang-curated-agent-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The [Agent Skills spec](https://github.com/anthropics/skills) is the emerging cr
 ### Domain-Specific
 
 - [K-Dense-AI/claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills) - Ready-to-use skills for research, science, engineering, analysis, finance and writing. ![GitHub stars](https://img.shields.io/github/stars/K-Dense-AI/claude-scientific-skills)
+- [matdev83/golang-curated-agent-skills](https://github.com/matdev83/golang-curated-agent-skills) - 44 portable Go skills for concurrency, context, testing, benchmarks, and idiomatic style. ![GitHub stars](https://img.shields.io/github/stars/matdev83/golang-curated-agent-skills)
 
 ### Collections
 


### PR DESCRIPTION
Adds [matdev83/golang-curated-agent-skills](https://github.com/matdev83/golang-curated-agent-skills) to the **Domain-Specific** section.

**Checking against CONTRIBUTING.md:**
- [x] SKILL.md format (agentskills.io spec, portable across Claude Code/Codex/Cursor/OpenCode/Gemini CLI)
- [x] No duplicate — searched first
- [x] Working link (checked automatically)
- [x] Relevant — 44 reusable Go agent skills for engineering workflows
- [x] Concise description (<120 chars)
- [x] One entry per PR

**Description:** Curated portable Go skills covering concurrency, context, testing, benchmarks, gRPC, error handling, security, and idiomatic style. Normalized derivative of samber/cc-skills-golang (foundational set by Samber) + Cursor's thermonuclear review skill. MIT, maintained, README with 44-skill index.