### PR TITLE
Add OrkasVideoStudio to domain-specific skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The [Agent Skills spec](https://github.com/anthropics/skills) is the emerging cr
 ### Domain-Specific
 
 - [K-Dense-AI/claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills) - Ready-to-use skills for research, science, engineering, analysis, finance and writing. ![GitHub stars](https://img.shields.io/github/stars/K-Dense-AI/claude-scientific-skills)
+- [Orkas-AI/Orkas-VideoStudio](https://github.com/Orkas-AI/Orkas-VideoStudio) - Video-production skills with editable `plan.json` timelines and CLI/MCP tooling. ![GitHub stars](https://img.shields.io/github/stars/Orkas-AI/Orkas-VideoStudio)
 
 ### Collections
 


### PR DESCRIPTION
## Summary

Adds OrkasVideoStudio as a domain-specific video-production skill collection with editable plan.json timelines and CLI/MCP tooling.

## Validation

- Confirmed the repository is not already listed
- Followed alphabetical order and the required entry format
- The project has 523 GitHub stars and active maintenance
- `git diff --check` passes

This is a project-affiliated submission.