### PR TITLE
Add SandBase CLI to MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ The [Model Context Protocol](https://modelcontextprotocol.io) (MCP) is an open s
 
 - [modelcontextprotocol/servers](https://github.com/modelcontextprotocol/servers) - Official reference MCP server implementations. ![GitHub stars](https://img.shields.io/github/stars/modelcontextprotocol/servers)
 - [Official MCP Registry](https://registry.modelcontextprotocol.io) - Authoritative registry with open API spec. ![GitHub stars](https://img.shields.io/github/stars/modelcontextprotocol/registry)
+- [SandBase CLI](https://github.com/sandbaseai/cli) - Provider-agnostic CLI and local MCP bridge connecting 25 AI clients to 2,000+ models/APIs. ![GitHub stars](https://img.shields.io/github/stars/sandbaseai/cli)
 
 ### Awesome Lists
 


### PR DESCRIPTION
## Add SandBase CLI to MCP Servers

SandBase CLI is an open-source MCP tool that fits this directory's cross-platform scope. Its local bridge exposes a provider-agnostic interface for 25 AI clients and 2,000+ models/APIs.

- Repository: https://github.com/sandbaseai/cli
- License: Apache-2.0
- Current release: v0.1.17
- The entry includes the requested GitHub stars badge and stays under the description length limit.
