### PR TITLE
feat: add falsify — reasoning & scientific thinking skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The [Agent Skills spec](https://github.com/anthropics/skills) is the emerging cr
 ### Domain-Specific
 
 - [K-Dense-AI/claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills) - Ready-to-use skills for research, science, engineering, analysis, finance and writing. ![GitHub stars](https://img.shields.io/github/stars/K-Dense-AI/claude-scientific-skills)
+- [263311487-ux/falsify](https://github.com/263311487-ux/falsify) - Falsification-first scientific thinking protocol: 5-stage loop that makes agents separate falsifiable claims from untestable ones and stop overconfident answers. ![GitHub stars](https://img.shields.io/github/stars/263311487-ux/falsify)
 
 ### Collections
 


### PR DESCRIPTION
## What

Adds [falsify](https://github.com/263311487-ux/falsify) under **Domain-Specific** in Agent Skills (SKILL.md).

## Why

- Self-contained `SKILL.md` (single file, well under 500 lines) that installs a falsification-first scientific reasoning loop on any agent: claim → design test → falsify → label uncertainty → conclude.
- Cross-platform: works with Claude Code, Codex, Cursor, Antigravity, Gemini CLI, Copilot — matches the repo's SKILL.md standard.
- Tested: ships with an eval suite, npm install (`falsify-skill`), MIT license, actively maintained.
- It's a meta-skill: improves every other skill's reliability by filtering confident-but-unverifiable claims before the final answer.