### PR TITLE
Add d1v deployment skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The [Agent Skills spec](https://github.com/anthropics/skills) is the emerging cr
 ### Domain-Specific
 
 - [K-Dense-AI/claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills) - Ready-to-use skills for research, science, engineering, analysis, finance and writing. ![GitHub stars](https://img.shields.io/github/stars/K-Dense-AI/claude-scientific-skills)
+- [d1v](https://github.com/d1vai/d1v-cli/tree/main/skills/d1v) - Deployment workflow skill for Claude Code and Codex with verified previews and confirmed production releases. ![GitHub stars](https://img.shields.io/github/stars/d1vai/d1v-cli)
 
 ### Collections
 


### PR DESCRIPTION
## Summary

Adds the official [d1v deployment Skill](https://github.com/d1vai/d1v-cli/tree/main/skills/d1v) to **Agent Skills (SKILL.md) -> Domain-Specific**.

The Skill supports Claude Code and Codex, guides web-project deployment, waits for a verified Preview result, and requires an interactive terminal plus explicit confirmation before a Production release.

## Checklist

- [x] Link points to the canonical Skill path.
- [x] The linked public source is MIT licensed, documented, and recently active.
- [x] The entry is a reusable `SKILL.md` workflow and is not duplicated in the list.
- [x] Description is factual, under 120 characters, and uses the repository's star-badge format.
- [x] One entry only; `git diff --check` passed.

Disclosure: I am affiliated with d1v, the maintainer of the linked Skill. No target-project commands were run.
