### PR TITLE
Add SandBase Harness MCP runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ The [Agent Skills spec](https://github.com/anthropics/skills) is the emerging cr
 
 The [Model Context Protocol](https://modelcontextprotocol.io) (MCP) is an open standard for connecting AI models to data sources and tools. 17,000+ servers across directories.
 
+### Runtime & Infrastructure
+
+- [sandbaseai/sandbase-harness](https://github.com/sandbaseai/sandbase-harness) - Local-first, self-hosted AI-agent runtime and MCP bridge with persistent sessions, governed tool access, approvals, credentials, audit/replay, and selectable execution backends. ![GitHub stars](https://img.shields.io/github/stars/sandbaseai/sandbase-harness)
+
 ### Official
 
 - [modelcontextprotocol/servers](https://github.com/modelcontextprotocol/servers) - Official reference MCP server implementations. ![GitHub stars](https://img.shields.io/github/stars/modelcontextprotocol/servers)


### PR DESCRIPTION
## Summary

- add SandBase Harness to the MCP Servers runtime and infrastructure section
- link the official repository and GitHub star badge
- describe the documented local-first/self-hosted runtime capabilities factually

## Verification

- `git diff --check`

Disclosure: I maintain/contribute to SandBase Harness and am submitting this entry on behalf of the project. The description does not claim directory endorsement or security certification; isolation depends on the selected backend and deployment configuration.
