### PR TITLE
Add BulkPublish social media skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The [Agent Skills spec](https://github.com/anthropics/skills) is the emerging cr
 ### Domain-Specific
 
 - [K-Dense-AI/claude-scientific-skills](https://github.com/K-Dense-AI/claude-scientific-skills) - Ready-to-use skills for research, science, engineering, analysis, finance and writing. ![GitHub stars](https://img.shields.io/github/stars/K-Dense-AI/claude-scientific-skills)
+- [azeemkafridi/bulkpublish-api](https://github.com/azeemkafridi/bulkpublish-api/tree/main/skills/social-media-content-skills) - 24 social media content skills for AI agents, backed by a publishing API and MCP server. ![GitHub stars](https://img.shields.io/github/stars/azeemkafridi/bulkpublish-api)
 
 ### Collections
 


### PR DESCRIPTION
Adds BulkPublish’s social-media content skill collection to the Domain-Specific section. The collection contains 24 reusable skills for AI-agent planning, adaptation, review, scheduling, and publishing.\n\nSkills: https://github.com/azeemkafridi/bulkpublish-api/tree/main/skills/social-media-content-skills\nAPI: https://github.com/azeemkafridi/bulkpublish-api\nMCP docs: https://app.bulkpublish.com/docs\n\nDisclosure: I am affiliated with BulkPublish and am submitting this entry for consideration.