### PR TITLE
Add Slashskills skill collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The [Agent Skills spec](https://github.com/anthropics/skills) is the emerging cr
 
 - [ComposioHQ/awesome-claude-skills](https://github.com/ComposioHQ/awesome-claude-skills) - Largest Claude skills list. ![GitHub stars](https://img.shields.io/github/stars/ComposioHQ/awesome-claude-skills)
 - [sickn33/antigravity-awesome-skills](https://github.com/sickn33/antigravity-awesome-skills) - 900+ installable skills. Cross-platform. `npx antigravity-awesome-skills` to install. ![GitHub stars](https://img.shields.io/github/stars/sickn33/antigravity-awesome-skills)
+- [tushaarmehtaa/tushar-skills](https://github.com/tushaarmehtaa/tushar-skills) - Skills for software design, implementation, release checks, and documentation. ![GitHub stars](https://img.shields.io/github/stars/tushaarmehtaa/tushar-skills)
 - [VoltAgent/awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills) - 380+ skills for Claude Code, Codex, Antigravity, Gemini CLI, Cursor. ![GitHub stars](https://img.shields.io/github/stars/VoltAgent/awesome-agent-skills)
 - [travisvn/awesome-claude-skills](https://github.com/travisvn/awesome-claude-skills) - Claude Code workflow-focused skills. ![GitHub stars](https://img.shields.io/github/stars/travisvn/awesome-claude-skills)
 - [heilcheng/awesome-agent-skills](https://github.com/heilcheng/awesome-agent-skills) - Skills + tools + tutorials for Claude, Codex, Antigravity, Copilot. ![GitHub stars](https://img.shields.io/github/stars/heilcheng/awesome-agent-skills)


### PR DESCRIPTION
Add the Slashskills repository to Agent Skills → Collections. It contains installable software-development workflows, with per-runtime installation documentation and explicit tool requirements.

- One README entry; description is under 120 characters.
- Canonical repository link and requested stars badge.
- Repository has 11 stars at submission preparation and recent maintenance.
- No existing listing or open duplicate PR found.

Affiliation: I maintain Slashskills (tushaarmehtaa/tushar-skills). This submission was prepared with AI assistance.

The upstream repository is MIT-licensed and documents installation and required tools. Runtime instructions are documented; repository validation and website tests are not presented as proof of end-to-end skill performance.
